### PR TITLE
Remove unused actions and renamed dialog

### DIFF
--- a/src/FirstInstall/FirstInstallDialog.jsx
+++ b/src/FirstInstall/FirstInstallDialog.jsx
@@ -39,20 +39,20 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import ConfirmationDialog from '../ConfirmationDialog/ConfirmationDialog';
 import {
-    hideFirstInstallDialogs,
-    isOfferDialogVisible,
+    hideFirstInstallDialog,
+    isDialogVisible,
 } from './firstInstallReducer';
 
 export default () => {
     const dispatch = useDispatch();
-    const isVisible = useSelector(isOfferDialogVisible);
+    const isVisible = useSelector(isDialogVisible);
 
     return (
         <ConfirmationDialog
             isVisible={isVisible}
             title="First steps with nRF Connect SDK"
             confirmLabel="Close"
-            onConfirm={() => dispatch(hideFirstInstallDialogs())}
+            onConfirm={() => dispatch(hideFirstInstallDialog())}
         >
             <p>
                 Currently tools as well as the nRF Connect SDK (NCS) are

--- a/src/FirstInstall/firstInstallReducer.js
+++ b/src/FirstInstall/firstInstallReducer.js
@@ -34,57 +34,39 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-const SHOW_FIRST_INSTALL_OFFER_DIALOG = 'SHOW_FIRST_INSTALL_OFFER_DIALOG';
-export const showFirstInstallOfferDialog = toolchainDir => ({
-    type: SHOW_FIRST_INSTALL_OFFER_DIALOG,
+const SHOW_FIRST_INSTALL_DIALOG = 'SHOW_FIRST_INSTALL_DIALOG';
+export const showFirstInstallDialog = toolchainDir => ({
+    type: SHOW_FIRST_INSTALL_DIALOG,
     toolchainDir,
 });
 
-const SHOW_FIRST_INSTALL_INSTRUCTIONS_DIALOG = 'SHOW_FIRST_INSTALL_INSTRUCTIONS_DIALOG';
-export const showFirstInstallInstructionsDialog = toolchainDir => ({
-    type: SHOW_FIRST_INSTALL_INSTRUCTIONS_DIALOG,
-    toolchainDir,
-});
-
-const HIDE_FIRST_INSTALL_DIALOGS = 'HIDE_FIRST_INSTALL_DIALOGS';
-export const hideFirstInstallDialogs = () => ({
-    type: HIDE_FIRST_INSTALL_DIALOGS,
+const HIDE_FIRST_INSTALL_DIALOG = 'HIDE_FIRST_INSTALL_DIALOG';
+export const hideFirstInstallDialog = () => ({
+    type: HIDE_FIRST_INSTALL_DIALOG,
 });
 
 const initialState = {
     toolchainDir: null,
-    isOfferDialogVisible: false,
-    isInstructionsDialogVisible: false,
+    isDialogVisible: false,
 };
 
 export default (state = initialState, action) => {
     switch (action.type) {
-        case SHOW_FIRST_INSTALL_OFFER_DIALOG:
+        case SHOW_FIRST_INSTALL_DIALOG:
             return {
                 ...state,
-                isOfferDialogVisible: true,
-                isInstructionsDialogVisible: false,
+                isDialogVisible: true,
                 toolchainDir: action.toolchainDir,
             };
-        case SHOW_FIRST_INSTALL_INSTRUCTIONS_DIALOG:
+        case HIDE_FIRST_INSTALL_DIALOG:
             return {
                 ...state,
-                isOfferDialogVisible: false,
-                isInstructionsDialogVisible: true,
-                toolchainDir: action.toolchainDir || state.toolchainDir,
-            };
-        case HIDE_FIRST_INSTALL_DIALOGS:
-            return {
-                ...state,
-                isOfferDialogVisible: false,
-                isInstructionsDialogVisible: false,
+                isDialogVisible: false,
             };
         default:
             return state;
     }
 };
 
-export const isOfferDialogVisible = state => state.app.firstInstall.isOfferDialogVisible;
+export const isDialogVisible = state => state.app.firstInstall.isDialogVisible;
 export const toolchainDir = state => state.app.firstInstall.toolchainDir;
-export const isInstructionsDialogVisible = state => (
-    state.app.firstInstall.isInstructionsDialogVisible);

--- a/src/ManagerView/ManagerView.jsx
+++ b/src/ManagerView/ManagerView.jsx
@@ -37,7 +37,7 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import FirstInstallOfferDialog from '../FirstInstall/FirstInstallOfferDialog';
+import FirstInstallDialog from '../FirstInstall/FirstInstallDialog';
 import InstallDirDialog from '../SettingsView/InstallDirDialog';
 import { selectInstallDir } from '../SettingsView/settingsActions';
 import EnvironmentList from './EnvironmentList/EnvironmentList';
@@ -57,7 +57,7 @@ export default props => {
         return (
             <div {...props}>
                 <EnvironmentList />
-                <FirstInstallOfferDialog />
+                <FirstInstallDialog />
                 <InstallDirDialog
                     isVisible={isInstallDirDialogVisible}
                     title="Confirm installation directory"

--- a/src/ManagerView/managerActions.js
+++ b/src/ManagerView/managerActions.js
@@ -44,7 +44,7 @@ import { remote, shell } from 'electron';
 import fse from 'fs-extra';
 import semver from 'semver';
 import { isFirstInstall, setHasInstalledAnNcs } from '../util/persistentStore';
-import { showFirstInstallOfferDialog } from '../FirstInstall/firstInstallReducer';
+import { showFirstInstallDialog } from '../FirstInstall/firstInstallReducer';
 
 const { net } = remote;
 
@@ -306,7 +306,7 @@ const install = (environmentVersion, toolchainVersion) => async (dispatch, getSt
     const unzipDest = path.resolve(installDir, environmentVersion, toolchainDir);
 
     if (isFirstInstall()) {
-        dispatch(showFirstInstallOfferDialog(unzipDest));
+        dispatch(showFirstInstallDialog(unzipDest));
     }
 
     dispatch(environmentInProcessAction(environmentVersion, true));


### PR DESCRIPTION
This PR removes "offer" from the name of the FirstInstallDialog, its states and actions. Also cleans unused states and actions which used to show secondary instruction dialog.