### PR TITLE
Fix updating ncs

### DIFF
--- a/src/InstallDir/InstallDirDialog.jsx
+++ b/src/InstallDir/InstallDirDialog.jsx
@@ -77,7 +77,7 @@ export default () => {
         confirmLabel: 'Continue installation',
         onConfirm: () => {
             dispatch(hideInstallDirDialog());
-            install(dispatch, environment);
+            install(dispatch, environment, false);
         },
         onCancel: () => dispatch(hideInstallDirDialog()),
         optionalLabel: 'Change directory',

--- a/src/Manager/Environment/EnvironmentMenu.jsx
+++ b/src/Manager/Environment/EnvironmentMenu.jsx
@@ -43,9 +43,8 @@ import path from 'path';
 import { shell } from 'electron';
 import Dropdown from 'react-bootstrap/Dropdown';
 import DropdownButton from 'react-bootstrap/DropdownButton';
-import { cloneNcs } from './environmentEffects';
+import { cloneNcs, install } from './environmentEffects';
 import { isInstalled, toolchainDir as getToolchainDir, version as getVersion } from './environmentReducer';
-import { showConfirmInstallDirDialog } from '../../InstallDir/installDirReducer';
 import { showConfirmRemoveDialog } from '../managerReducer';
 
 import environmentPropType from './environmentPropType';
@@ -83,7 +82,7 @@ const EnvironmentMenu = ({ environment }) => {
             <Dropdown.Item onClick={() => openDirectory(toolchainDir)}>Open toolchain directory</Dropdown.Item>
             <Dropdown.Divider />
             <Dropdown.Item onClick={() => cloneNcs(dispatch, version, toolchainDir)}>Update SDK</Dropdown.Item>
-            <Dropdown.Item onClick={() => dispatch(showConfirmInstallDirDialog(version))}>Update toolchain</Dropdown.Item>
+            <Dropdown.Item onClick={() => install(dispatch, environment)}>Update toolchain</Dropdown.Item>
             <Dropdown.Divider />
             <Dropdown.Item onClick={() => dispatch(showConfirmRemoveDialog(version))}>Remove</Dropdown.Item>
             {/* eslint-enable max-len */}

--- a/src/Manager/Environment/EnvironmentMenu.jsx
+++ b/src/Manager/Environment/EnvironmentMenu.jsx
@@ -81,8 +81,8 @@ const EnvironmentMenu = ({ environment }) => {
             <Dropdown.Item onClick={() => openDirectory(path.dirname(toolchainDir))}>Open SDK directory</Dropdown.Item>
             <Dropdown.Item onClick={() => openDirectory(toolchainDir)}>Open toolchain directory</Dropdown.Item>
             <Dropdown.Divider />
-            <Dropdown.Item onClick={() => cloneNcs(dispatch, version, toolchainDir)}>Update SDK</Dropdown.Item>
-            <Dropdown.Item onClick={() => install(dispatch, environment)}>Update toolchain</Dropdown.Item>
+            <Dropdown.Item onClick={() => cloneNcs(dispatch, version, toolchainDir, true)}>Update SDK</Dropdown.Item>
+            <Dropdown.Item onClick={() => install(dispatch, environment, true)}>Update toolchain</Dropdown.Item>
             <Dropdown.Divider />
             <Dropdown.Item onClick={() => dispatch(showConfirmRemoveDialog(version))}>Remove</Dropdown.Item>
             {/* eslint-enable max-len */}


### PR DESCRIPTION
This is part of fixing [NCP-2997](https://projecttools.nordicsemi.no/jira/browse/NCP-2997).

The previous implementation sometimes corrupted the installation. The new implementation does respect whether a new NCS is installed or whether it is just updated. In the latter case, a possibly existing directory `.west` must not be removed and the script `ncsmgr init-ncs` should not call `west init`. For this, the new implementation requires an updated version of the toolchain, that honors passing the parameter `--just-update` to the script `ncsmgr init-ncs`. This update is implemented in NordicPlayground/toolchain#26.

This new implementation follows the logic as described in
https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/gs_installing.html#updating-the-repositories

With this implementation, the progress bars also show up correctly while updating a toolchain or NCS.