### PR TITLE
Add macOS support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Add macOS support
+
 ## Version 0.5.0
 - First public release
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,5 @@
-## Unreleased
-- Add macOS support
+## Version 0.6.0
+- Add macOS support #39
 
 ## Version 0.5.0
 - First public release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-toolchain-manager",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Install and manage tools to develop with the nRF Connect SDK (NCS)",
   "displayName": "Toolchain Manager",
   "repository": {

--- a/src/Manager/Environment/EnvironmentMenu.jsx
+++ b/src/Manager/Environment/EnvironmentMenu.jsx
@@ -57,6 +57,16 @@ const openCmd = directory => {
     exec(`start cmd /k "${path.resolve(directory, 'git-cmd.cmd')}"`);
 };
 
+const openTerminal = directory => {
+    const d = path.dirname(directory);
+    exec(`osascript <<END
+tell application "Terminal"
+    do script "cd ${d} ; export PATH=${d}/toolchain/bin:$PATH ; clear"
+    activate
+end tell
+END`);
+};
+
 const openDirectory = directory => {
     shell.openItem(directory);
 };
@@ -75,8 +85,15 @@ const EnvironmentMenu = ({ environment }) => {
             disabled={!isInstalled(environment)}
         >
             {/* eslint-disable max-len */}
-            <Dropdown.Item onClick={() => openBash(toolchainDir)}>Open bash</Dropdown.Item>
-            <Dropdown.Item onClick={() => openCmd(toolchainDir)}>Open command prompt</Dropdown.Item>
+            {process.platform === 'win32' && (
+                <>
+                    <Dropdown.Item onClick={() => openBash(toolchainDir)}>Open bash</Dropdown.Item>
+                    <Dropdown.Item onClick={() => openCmd(toolchainDir)}>Open command prompt</Dropdown.Item>
+                </>
+            )}
+            {process.platform !== 'win32' && (
+                <Dropdown.Item onClick={() => openTerminal(toolchainDir)}>Open Terminal</Dropdown.Item>
+            )}
             <Dropdown.Divider />
             <Dropdown.Item onClick={() => openDirectory(path.dirname(toolchainDir))}>Open SDK directory</Dropdown.Item>
             <Dropdown.Item onClick={() => openDirectory(toolchainDir)}>Open toolchain directory</Dropdown.Item>

--- a/src/Manager/Environment/EnvironmentMenu.jsx
+++ b/src/Manager/Environment/EnvironmentMenu.jsx
@@ -40,6 +40,7 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import { exec } from 'child_process';
 import path from 'path';
+import { readdirSync } from 'fs';
 import { shell } from 'electron';
 import Dropdown from 'react-bootstrap/Dropdown';
 import DropdownButton from 'react-bootstrap/DropdownButton';
@@ -59,9 +60,16 @@ const openCmd = directory => {
 
 const openTerminal = directory => {
     const d = path.dirname(directory);
+    const gitversion = readdirSync(`${d}/toolchain/Cellar/git`).pop();
+    const env = [
+        `export PATH=${d}/toolchain/bin:$PATH`,
+        `export GIT_EXEC_PATH=${d}/toolchain/Cellar/git/${gitversion}/libexec/git-core`,
+        'export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb',
+        `export GNUARMEMB_TOOLCHAIN_PATH=${d}/toolchain`,
+    ];
     exec(`osascript <<END
 tell application "Terminal"
-    do script "cd ${d} ; export PATH=${d}/toolchain/bin:$PATH ; clear"
+    do script "cd ${d} ; ${env.join(' ; ')} ; clear"
     activate
 end tell
 END`);

--- a/src/Manager/Environment/EnvironmentMenu.jsx
+++ b/src/Manager/Environment/EnvironmentMenu.jsx
@@ -92,25 +92,39 @@ const EnvironmentMenu = ({ environment }) => {
             alignRight
             disabled={!isInstalled(environment)}
         >
-            {/* eslint-disable max-len */}
             {process.platform === 'win32' && (
                 <>
-                    <Dropdown.Item onClick={() => openBash(toolchainDir)}>Open bash</Dropdown.Item>
-                    <Dropdown.Item onClick={() => openCmd(toolchainDir)}>Open command prompt</Dropdown.Item>
+                    <Dropdown.Item onClick={() => openBash(toolchainDir)}>
+                        Open bash
+                    </Dropdown.Item>
+                    <Dropdown.Item onClick={() => openCmd(toolchainDir)}>
+                        Open command prompt
+                    </Dropdown.Item>
                 </>
             )}
             {process.platform !== 'win32' && (
-                <Dropdown.Item onClick={() => openTerminal(toolchainDir)}>Open Terminal</Dropdown.Item>
+                <Dropdown.Item onClick={() => openTerminal(toolchainDir)}>
+                    Open Terminal
+                </Dropdown.Item>
             )}
             <Dropdown.Divider />
-            <Dropdown.Item onClick={() => openDirectory(path.dirname(toolchainDir))}>Open SDK directory</Dropdown.Item>
-            <Dropdown.Item onClick={() => openDirectory(toolchainDir)}>Open toolchain directory</Dropdown.Item>
+            <Dropdown.Item onClick={() => openDirectory(path.dirname(toolchainDir))}>
+                Open SDK directory
+            </Dropdown.Item>
+            <Dropdown.Item onClick={() => openDirectory(toolchainDir)}>
+                Open toolchain directory
+            </Dropdown.Item>
             <Dropdown.Divider />
-            <Dropdown.Item onClick={() => cloneNcs(dispatch, version, toolchainDir, true)}>Update SDK</Dropdown.Item>
-            <Dropdown.Item onClick={() => install(dispatch, environment, true)}>Update toolchain</Dropdown.Item>
+            <Dropdown.Item onClick={() => cloneNcs(dispatch, version, toolchainDir, true)}>
+                Update SDK
+            </Dropdown.Item>
+            <Dropdown.Item onClick={() => install(dispatch, environment, true)}>
+                Update toolchain
+            </Dropdown.Item>
             <Dropdown.Divider />
-            <Dropdown.Item onClick={() => dispatch(showConfirmRemoveDialog(version))}>Remove</Dropdown.Item>
-            {/* eslint-enable max-len */}
+            <Dropdown.Item onClick={() => dispatch(showConfirmRemoveDialog(version))}>
+                Remove
+            </Dropdown.Item>
         </DropdownButton>
     );
 };

--- a/src/Manager/Environment/Install.jsx
+++ b/src/Manager/Environment/Install.jsx
@@ -41,16 +41,22 @@ import { showConfirmInstallDirDialog } from '../../InstallDir/installDirReducer'
 import Button from './Button';
 import environmentPropType from './environmentPropType';
 import { isOnlyAvailable, version } from './environmentReducer';
+import { install } from './environmentEffects';
 
 const Install = ({ environment }) => {
     const dispatch = useDispatch();
+    const { platform } = process;
+    const onClick = {
+        darwin: () => install(dispatch, environment, false),
+        win32: () => dispatch(showConfirmInstallDirDialog(version(environment))),
+    };
 
     if (!isOnlyAvailable(environment)) return null;
 
     return (
         <Button
             icon="x-mdi-briefcase-download-outline"
-            onClick={() => dispatch(showConfirmInstallDirDialog(version(environment)))}
+            onClick={onClick[platform]}
             label="Install"
             variant="outline-primary"
         />

--- a/src/Manager/Environment/environmentEffects.js
+++ b/src/Manager/Environment/environmentEffects.js
@@ -119,7 +119,7 @@ const unpack = async (src, dest, reportProgress) => {
                 .on('progress', (fileIndex, fileCount) => reportProgress(fileIndex, fileCount, 2))
                 .extract({ path: dest }));
         case 'darwin': {
-            const volume = execSync(`hdiutil attach ${src} | grep -Eo "/Volumes/ncs-toolchain-.*`).toString().trim();
+            const volume = execSync(`hdiutil attach ${src} | grep -Eo "/Volumes/ncs-toolchain-.*"`).toString().trim();
             await fse.copy(path.join(volume, 'toolchain'), dest);
             execSync(`hdiutil detach ${volume}`);
             break;

--- a/src/Manager/Environment/environmentPropType.jsx
+++ b/src/Manager/Environment/environmentPropType.jsx
@@ -35,7 +35,7 @@
  */
 
 import {
-    arrayOf, bool, number, shape, string,
+    arrayOf, oneOfType, bool, number, shape, string,
 } from 'prop-types';
 
 export default shape({
@@ -46,7 +46,7 @@ export default shape({
         name: string.isRequired,
         sha512: string.isRequired,
     }).isRequired),
-    progress: number,
+    progress: oneOfType([number, string]),
     isInstallingToolchain: bool,
     isCloningSdk: bool,
     isWestPresent: bool,

--- a/src/Manager/Environment/environmentReducer.js
+++ b/src/Manager/Environment/environmentReducer.js
@@ -132,7 +132,12 @@ export const progress = env => {
 export const progressLabel = env => {
     switch (true) {
         case isInstallingToolchain(env): return `Installing ${progress(env)}%`;
-        case isCloningSdk(env): return 'Cloning SDK... please wait until the terminal window is closed!';
+        case isCloningSdk(env): {
+            if (process.platform === 'win32') {
+                return 'Cloning SDK... please wait until the terminal window is closed!';
+            }
+            return env.progress;
+        }
         case isRemoving(env): return 'Removing...';
         default: return '';
     }

--- a/src/Manager/Environment/segger.test.js
+++ b/src/Manager/Environment/segger.test.js
@@ -84,7 +84,9 @@ expect.extend({
 });
 
 const expectNrfSettingAreCorrect = xml => {
-    expect(xml).toContainNode('settings setting[name="Nordic/ToolchainDir"]', toolchainDir);
+    if (process.platform === 'win32') {
+        expect(xml).toContainNode('settings setting[name="Nordic/ToolchainDir"]', toolchainDir);
+    }
     expect(xml).toContainNode('settings setting[name="Nordic/ZephyrBase"]', zephyrBase);
     expect(xml).toContainNode('settings setting[name="Nordic/CMakeExecutable"]', '');
     expect(xml).toContainNode('settings setting[name="Nordic/DTCExecutable"]', '');

--- a/src/Manager/Manager.jsx
+++ b/src/Manager/Manager.jsx
@@ -38,6 +38,7 @@ import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import ButtonToolbar from 'react-bootstrap/ButtonToolbar';
 import Button from 'react-bootstrap/Button';
+import Alert from 'react-bootstrap/Alert';
 
 import FirstInstallDialog from '../FirstInstall/FirstInstallDialog';
 
@@ -45,10 +46,21 @@ import Environment from './Environment/Environment';
 import RemoveEnvironmentDialog from './Environment/RemoveEnvironmentDialog';
 import initEnvironments from './initEnvironments';
 import OtherPlatformInstructions from './OtherPlatformInstructions';
-import { environmentsByVersion } from './managerReducer';
+import { environmentsByVersion, isMasterVisible } from './managerReducer';
+
 
 const Environments = () => {
-    const environments = useSelector(environmentsByVersion);
+    const masterVisible = useSelector(isMasterVisible);
+    const environments = useSelector(environmentsByVersion)
+        .filter(({ version }) => (version === 'master' ? masterVisible : true));
+
+    if (environments.length === 0) {
+        return (
+            <Alert variant="info" className="p-4 text-center">
+                There are no environments available for installation.
+            </Alert>
+        );
+    }
 
     return (
         <div>

--- a/src/Manager/Manager.jsx
+++ b/src/Manager/Manager.jsx
@@ -52,7 +52,11 @@ import { environmentsByVersion, isMasterVisible } from './managerReducer';
 const Environments = () => {
     const masterVisible = useSelector(isMasterVisible);
     const environments = useSelector(environmentsByVersion)
-        .filter(({ version }) => (version === 'master' ? masterVisible : true));
+        .filter(({ version, isInstalled }) => (
+            version === 'master'
+                ? isInstalled || masterVisible
+                : true
+        ));
 
     if (environments.length === 0) {
         return (

--- a/src/Manager/Manager.jsx
+++ b/src/Manager/Manager.jsx
@@ -63,7 +63,7 @@ export default props => {
     const dispatch = useDispatch();
     useEffect(() => initEnvironments(dispatch), [dispatch]);
 
-    const isSupportedPlatform = process.platform === 'win32';
+    const isSupportedPlatform = process.platform !== 'linux';
     if (!isSupportedPlatform) {
         return (
             <div {...props}>

--- a/src/Manager/initEnvironments.js
+++ b/src/Manager/initEnvironments.js
@@ -36,6 +36,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import { execSync } from 'child_process';
 
 import { remote } from 'electron';
 import fse from 'fs-extra';
@@ -82,6 +83,14 @@ const downloadIndex = dispatch => {
 };
 
 export default dispatch => {
+    const dir = path.dirname(installDir());
+    if (process.platform === 'darwin'
+        // eslint-disable-next-line no-bitwise
+        && (!fs.existsSync(dir) || (fs.statSync(dir) & 0o3775) !== 0o3775)) {
+        const prompt = `Base directory ${dir} needs to be created, to do this please...`;
+        const script = `install -d -g staff -m 3775 ${dir}`;
+        execSync(`osascript -e "do shell script \\"${script} \\" with prompt \\"${prompt} \\" with administrator privileges"`);
+    }
     fse.mkdirpSync(installDir());
     detectLocallyExistingEnvironments(dispatch);
     downloadIndex(dispatch);

--- a/src/Manager/initEnvironments.js
+++ b/src/Manager/initEnvironments.js
@@ -86,7 +86,7 @@ export default dispatch => {
     const dir = path.dirname(installDir());
     if (process.platform === 'darwin'
         // eslint-disable-next-line no-bitwise
-        && (!fs.existsSync(dir) || (fs.statSync(dir) & 0o3775) !== 0o3775)) {
+        && (!fs.existsSync(dir) || (fs.statSync(dir).mode & 0o3775) !== 0o3775)) {
         const prompt = `Base directory ${dir} needs to be created, to do this please...`;
         const script = `install -d -g staff -m 3775 ${dir}`;
         execSync(`osascript -e "do shell script \\"${script} \\" with prompt \\"${prompt} \\" with administrator privileges"`);

--- a/src/Manager/managerReducer.js
+++ b/src/Manager/managerReducer.js
@@ -36,6 +36,7 @@
 
 import semver from 'semver';
 import environmentReducer, { REMOVE_ENVIRONMENT, canBeDownloaded } from './Environment/environmentReducer';
+import { persistedShowMaster, setPersistedShowMaster } from '../persistentStore';
 
 const byVersion = (a, b) => {
     try {
@@ -88,6 +89,12 @@ export const hideConfirmRemoveDialog = () => ({
     type: HIDE_CONFIRM_REMOVE_DIALOG,
 });
 
+const SHOW_MASTER = 'SHOW_MASTER';
+export const showMasterEnvironment = visible => ({
+    type: SHOW_MASTER,
+    show: !!visible,
+});
+
 const append = (environments, environment) => ({
     ...environments,
     [environment.version]: {
@@ -124,6 +131,9 @@ const managerReducer = (state, action) => {
             return { ...state, isRemoveDirDialogVisible: true, versionToRemove: action.version };
         case HIDE_CONFIRM_REMOVE_DIALOG:
             return { ...state, isRemoveDirDialogVisible: false, versionToRemove: null };
+        case SHOW_MASTER:
+            setPersistedShowMaster(!!action.show);
+            return { ...state, isMasterVisible: !!action.show };
         case SELECT_ENVIRONMENT:
             return { ...state, selectedVersion: action.selectedVersion };
         default:
@@ -148,6 +158,7 @@ const maybeCallEnvironmentReducer = (state, action) => {
 const initialState = {
     environments: {},
     isRemoveDirDialogVisible: false,
+    isMasterVisible: persistedShowMaster(),
     versionToRemove: null,
     selectedVersion: null,
 };
@@ -170,3 +181,5 @@ export const selectedVersion = state => state.app.manager.selectedVersion;
 
 export const environmentsByVersion = state => (
     sortedByVersion(Object.values(state.app.manager.environments)));
+
+export const isMasterVisible = ({ app }) => app.manager.isMasterVisible;

--- a/src/NrfCard/nrfCard.scss
+++ b/src/NrfCard/nrfCard.scss
@@ -35,9 +35,8 @@
  */
 
 .nrf-card {
-    max-width: 800px;
     margin: auto;
-    height: 8em;
+    min-height: 8em;
 }
 
 .nrf-card:not(:first-of-type) {

--- a/src/Settings/Settings.jsx
+++ b/src/Settings/Settings.jsx
@@ -41,14 +41,17 @@ import { useDispatch, useSelector } from 'react-redux';
 import Button from 'react-bootstrap/Button';
 import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
+import Form from 'react-bootstrap/Form';
 
 import NrfCard from '../NrfCard/NrfCard';
 import { showSetInstallDirDialog, currentInstallDir } from '../InstallDir/installDirReducer';
+import { showMasterEnvironment, isMasterVisible } from '../Manager/managerReducer';
 
 export default props => {
     const dispatch = useDispatch();
     const installDir = useSelector(currentInstallDir);
     const disabled = process.platform !== 'win32';
+    const masterVisible = useSelector(isMasterVisible);
 
     return (
         <div {...props}>
@@ -71,6 +74,18 @@ export default props => {
                 <Row className="settings-info">
                     <Col className="text-muted">
                         {installDir}
+                    </Col>
+                </Row>
+
+                <Row className="settings-info mt-4">
+                    <Col>
+                        <Form.Group controlId="toggleMaster">
+                            <Form.Switch
+                                defaultChecked={masterVisible}
+                                onChange={() => dispatch(showMasterEnvironment(!masterVisible))}
+                                label="Show unstable (master branch) environment"
+                            />
+                        </Form.Group>
                     </Col>
                 </Row>
             </NrfCard>

--- a/src/Settings/Settings.jsx
+++ b/src/Settings/Settings.jsx
@@ -48,6 +48,7 @@ import { showSetInstallDirDialog, currentInstallDir } from '../InstallDir/instal
 export default props => {
     const dispatch = useDispatch();
     const installDir = useSelector(currentInstallDir);
+    const disabled = process.platform !== 'win32';
 
     return (
         <div {...props}>
@@ -59,6 +60,7 @@ export default props => {
                     <Col xs="auto">
                         <Button
                             variant="outline-primary"
+                            disabled={disabled}
                             onClick={() => dispatch(showSetInstallDirDialog())}
                         >
                             Select directory

--- a/src/persistentStore.js
+++ b/src/persistentStore.js
@@ -54,8 +54,8 @@ export const setPersistedInstallDir = dir => store.set('installDir', dir);
 
 const defaultIndexJson = {
     win32: 'index.json',
-    darwin: 'mac.json',
-    linux: 'linux.json',
+    darwin: 'index-mac.json',
+    linux: 'index-linux.json',
 }[process.platform];
 
 export const toolchainIndexUrl = () => store.get('toolchainIndexUrl',

--- a/src/persistentStore.js
+++ b/src/persistentStore.js
@@ -43,12 +43,24 @@ const store = new Store({ name: 'pc-nrfconnect-toolchain-manager' });
 export const isFirstInstall = () => store.get('isFirstInstall', true);
 export const setHasInstalledAnNcs = () => store.set('isFirstInstall', false);
 
-const defaultInstallDir = (process.platform === 'win32')
-    ? path.resolve(os.homedir(), 'ncs')
-    : '/opt/nordic/ncs';
+const defaultInstallDir = {
+    win32: path.resolve(os.homedir(), 'ncs'),
+    darwin: '/opt/nordic/ncs',
+    linux: '//TODO',
+}[process.platform];
 
 export const persistedInstallDir = () => store.get('installDir', defaultInstallDir);
 export const setPersistedInstallDir = dir => store.set('installDir', dir);
 
-export const toolchainIndexUrl = () => store.get('toolchainIndexUrl', 'https://developer.nordicsemi.com/.pc-tools/toolchain/index.json');
+const defaultIndexJson = {
+    win32: 'index.json',
+    darwin: 'mac.json',
+    linux: 'linux.json',
+}[process.platform];
+
+export const toolchainIndexUrl = () => store.get('toolchainIndexUrl',
+    `https://developer.nordicsemi.com/.pc-tools/toolchain/${defaultIndexJson}`);
 export const toolchainUrl = name => `${path.dirname(toolchainIndexUrl())}/${name}`;
+
+export const persistedShowMaster = () => store.get('showMaster', false);
+export const setPersistedShowMaster = visible => store.set('showMaster', visible);

--- a/src/persistentStore.js
+++ b/src/persistentStore.js
@@ -43,7 +43,10 @@ const store = new Store({ name: 'pc-nrfconnect-toolchain-manager' });
 export const isFirstInstall = () => store.get('isFirstInstall', true);
 export const setHasInstalledAnNcs = () => store.set('isFirstInstall', false);
 
-const defaultInstallDir = path.resolve(os.homedir(), 'ncs');
+const defaultInstallDir = (process.platform === 'win32')
+    ? path.resolve(os.homedir(), 'ncs')
+    : '/opt/nordic/ncs';
+
 export const persistedInstallDir = () => store.get('installDir', defaultInstallDir);
 export const setPersistedInstallDir = dir => store.set('installDir', dir);
 


### PR DESCRIPTION
This PR adds macOS support to Toolchain Manager
- separate json file is used as index to the toolchain bundles
- master environment is hidden by default and can be explicitly enabled in the settings
- changing base directory is disabled, since due to the way brew hardwires installation paths in binaries 

At the time of this PR the _master_ toolchain is not available for Windows, and the is the only available toolchain for macOS.