### PR TITLE
Install cmake support module

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 ## Unreleased
-- Feature: settings to change toolchain source
 - Linux toolchain support
+- Install cmake support modules
 
 ## Version 0.7.1
 - Fixed update SDK/toolchain actions

--- a/src/Manager/Environment/environmentEffects.js
+++ b/src/Manager/Environment/environmentEffects.js
@@ -161,6 +161,8 @@ const unpack = (version, src, dest) => async dispatch => {
 
 const installCMakeModules = toolchainDir => {
     const pkg = path.resolve(toolchainDir, 'cmake', 'NcsToolchainConfig.cmake');
+    if (!fs.existsSync(pkg)) return;
+
     switch (process.platform) {
         case 'win32': {
             const bash = path.resolve(toolchainDir, 'bin', 'bash.exe');

--- a/src/Manager/Environment/environmentEffects.js
+++ b/src/Manager/Environment/environmentEffects.js
@@ -165,8 +165,7 @@ const installCMakeModules = toolchainDir => {
 
     switch (process.platform) {
         case 'win32': {
-            const bash = path.resolve(toolchainDir, 'bin', 'bash.exe');
-            execSync(`${bash} -l -c "unset ZEPHYR_BASE ; cmake -P ${pkg}"`);
+            execSync(`${toolchainDir}/opt/bin/cmake -P ${pkg}"`);
             break;
         }
         case 'darwin':


### PR DESCRIPTION
This PR adds functionality to automatically install the cmake support module that is bundled with the toolchain.