### PR TITLE
Fix linux environment

### DIFF
--- a/src/Manager/Environment/EnvironmentMenu.jsx
+++ b/src/Manager/Environment/EnvironmentMenu.jsx
@@ -86,8 +86,9 @@ END`);
             .toString()
             .trim()
             .replace(/'/g, '');
+        const shortVer = version.replace(/\./g, '');
         exec(
-            `${terminalApp} -l -e "snap run --shell ncs-toolchain-${version}.west"`,
+            `${terminalApp} -l -e "snap run --shell ncs-toolchain-${shortVer}.west"`,
             { cwd: path.dirname(directory) }
         );
     },

--- a/src/Manager/Environment/environmentEffects.js
+++ b/src/Manager/Environment/environmentEffects.js
@@ -189,7 +189,8 @@ const unpack = (version, src, dest) => async dispatch => {
             );
             dispatch(setProgress(version, 'Installing...', 99));
             fse.removeSync(dest);
-            fse.symlinkSync(`/snap/ncs-toolchain-${version}/current`, dest);
+            const shortVer = version.replace(/\./g, '');
+            fse.symlinkSync(`/snap/ncs-toolchain-${shortVer}/current`, dest);
             break;
         }
         default:
@@ -283,13 +284,14 @@ export const cloneNcs = (
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 const { ZEPHYR_BASE, ...env } = process.env;
                 env.PATH = `${toolchainDir}/bin:${remote.process.env.PATH}`;
+                const shortVer = version.replace(/\./g, '');
 
                 ncsMgr = remoteSpawn(
                     'snap',
                     [
                         'run',
                         '--shell',
-                        `ncs-toolchain-${version}.west`,
+                        `ncs-toolchain-${shortVer}.west`,
                         '-c',
                         `${toolchainDir}/ncsmgr/ncsmgr init-ncs ${update}`,
                     ],

--- a/src/Manager/Environment/segger.js
+++ b/src/Manager/Environment/segger.js
@@ -186,9 +186,11 @@ export const openSegger = async (toolchainDir, version) => {
                 }
             );
             break;
-        case 'linux':
-            remoteExec(`snap run ncs-toolchain-${version}.emstudio`, { cwd });
+        case 'linux': {
+            const shortVer = version.replace(/\./g, '');
+            remoteExec(`ncs-toolchain-${shortVer}.emstudio`, { cwd });
             break;
+        }
         default:
     }
 };

--- a/src/Settings/Settings.jsx
+++ b/src/Settings/Settings.jsx
@@ -58,7 +58,7 @@ import {
 export default props => {
     const dispatch = useDispatch();
     const installDir = useSelector(currentInstallDir);
-    const disabled = process.platform !== 'win32';
+    const disabled = process.platform === 'darwin';
     const masterVisible = useSelector(isMasterVisible);
     const toolchainUrl = useSelector(toolchainRootUrl);
 

--- a/src/persistentStore.js
+++ b/src/persistentStore.js
@@ -46,7 +46,7 @@ export const setHasInstalledAnNcs = () => store.set('isFirstInstall', false);
 const defaultInstallDir = {
     win32: path.resolve(os.homedir(), 'ncs'),
     darwin: '/opt/nordic/ncs',
-    linux: '//TODO',
+    linux: path.resolve(os.homedir(), 'ncs'),
 }[process.platform];
 
 export const persistedInstallDir = () =>


### PR DESCRIPTION
Since there's a difference in the NCS tag/version (e.g. 'v1.4.0-rc1') and the snap version which does not allow dots: i.e. 'v140-rc1', the reference to the snap installation needs some adjustments.
For this to work the toolchain build will be updated.