### PR TITLE
Remove cmake package install

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,5 @@
-## Unreleased
+## Version 0.8.0
 - Linux toolchain support
-- Install cmake support modules
 
 ## Version 0.7.1
 - Fixed update SDK/toolchain actions

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 ## Unreleased
-- Feature: settings to change toolchain source
 - Linux toolchain support
+- Install cmake support modules
 
 ## Version 0.7.1
 - Fixed update SDK/toolchain actions

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ steps:
     versionSpec: 10
 - script: |
     set -o errexit -o pipefail
-    npm i
+    npm ci
     npm run lint
     npm run test
     npm run build

--- a/src/Manager/Environment/environmentEffects.js
+++ b/src/Manager/Environment/environmentEffects.js
@@ -161,6 +161,8 @@ const unpack = (version, src, dest) => async dispatch => {
 
 const installCMakeModules = toolchainDir => {
     const pkg = path.resolve(toolchainDir, 'cmake', 'NcsToolchainConfig.cmake');
+    if (!fs.existsSync(pkg)) return;
+
     switch (process.platform) {
         case 'win32': {
             const bash = path.resolve(toolchainDir, 'bin', 'bash.exe');

--- a/src/Manager/Environment/environmentEffects.js
+++ b/src/Manager/Environment/environmentEffects.js
@@ -198,27 +198,6 @@ const unpack = (version, src, dest) => async dispatch => {
     return undefined;
 };
 
-const installCMakeModules = toolchainDir => {
-    const pkg = path.resolve(toolchainDir, 'cmake', 'NcsToolchainConfig.cmake');
-    if (!fs.existsSync(pkg)) return;
-
-    switch (process.platform) {
-        case 'win32': {
-            execSync(`${toolchainDir}/opt/bin/cmake -P ${pkg}"`);
-            break;
-        }
-        case 'darwin':
-        case 'linux': {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const { ZEPHYR_BASE, ...env } = remote.process.env;
-            env.PATH = `${toolchainDir}/bin:${remote.process.env.PATH}`;
-            execSync(`cmake -P ${pkg}`, { env });
-            break;
-        }
-        default:
-    }
-};
-
 const installToolchain = (
     version,
     toolchain,
@@ -230,7 +209,6 @@ const installToolchain = (
         fse.mkdirpSync(toolchainDir);
         const packageLocation = await dispatch(download(version, toolchain));
         await dispatch(unpack(version, packageLocation, toolchainDir));
-        installCMakeModules(toolchainDir);
     } catch (error) {
         dispatch(showErrorDialog(`${error.message || error}`));
     }
@@ -403,7 +381,6 @@ export const installPackage = urlOrFilePath => async dispatch => {
             : await dispatch(download(version, { uri: urlOrFilePath }));
 
         await dispatch(unpack(version, filePath, toolchainDir));
-        installCMakeModules(toolchainDir);
         dispatch(finishInstallToolchain(version, toolchainDir));
         await dispatch(cloneNcs(version, toolchainDir, false));
     } catch (error) {

--- a/src/Manager/Environment/environmentEffects.js
+++ b/src/Manager/Environment/environmentEffects.js
@@ -165,8 +165,7 @@ const installCMakeModules = toolchainDir => {
 
     switch (process.platform) {
         case 'win32': {
-            const bash = path.resolve(toolchainDir, 'bin', 'bash.exe');
-            execSync(`${bash} -l -c "unset ZEPHYR_BASE ; cmake -P ${pkg}"`);
+            execSync(`${toolchainDir}/opt/bin/cmake -P ${pkg}"`);
             break;
         }
         case 'darwin':


### PR DESCRIPTION
This PR reverts the functionality of installing the cmake packages, since it is now included in the init-ncs script carried by the toolchain.