### PR TITLE
Disable linux environment

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,8 @@
 ## Version 0.8.0
-- Linux toolchain support
 - Fixed unzipping issue on Windows
 - Fixed incorrect percentage number for download progress
 - Update SES default config with tool paths
 - Added usage statistics
-- Added link about snap installation
 
 ## Version 0.7.1
 - Fixed update SDK/toolchain actions

--- a/src/Manager/Environment/EnvironmentMenu.jsx
+++ b/src/Manager/Environment/EnvironmentMenu.jsx
@@ -136,7 +136,7 @@ END
         ].join(' ');
 
         remoteExec(
-            `${terminalApp} -- -e "${e} bash"`,
+            `${terminalApp} -- bash -c "${e} bash"`,
             { cwd: path.dirname(toolchainDir) },
             execCallback
         );

--- a/src/Manager/Manager.jsx
+++ b/src/Manager/Manager.jsx
@@ -56,7 +56,7 @@ import {
     isShowingFirstSteps,
     showInstallPackageDialog,
 } from './managerReducer';
-import PlatformInstructions from './PlatformInstructions';
+import PlatformInstructions, { enableLinux } from './PlatformInstructions';
 
 const Environments = () => {
     const dispatch = useDispatch();
@@ -125,21 +125,25 @@ export default props => {
             {...props}
         >
             <PlatformInstructions />
-            <Environments />
-            <ButtonToolbar className="pt-3 flex-row justify-content-end">
-                <Button
-                    variant="link"
-                    className="mdi x-mdi-briefcase-plus-outline pr-0 pt-0"
-                    onClick={() => dispatch(showInstallPackageDialog())}
-                >
-                    Install package from other source
-                </Button>
-            </ButtonToolbar>
-            <FirstInstallDialog />
-            <RemoveEnvironmentDialog />
-            <InstallPackageDialog />
-            <ToolchainSourceDialog />
-            <InstallDirDialog />
+            {(process.platform !== 'linux' || enableLinux) && (
+                <>
+                    <Environments />
+                    <ButtonToolbar className="pt-3 flex-row justify-content-end">
+                        <Button
+                            variant="link"
+                            className="mdi x-mdi-briefcase-plus-outline pr-0 pt-0"
+                            onClick={() => dispatch(showInstallPackageDialog())}
+                        >
+                            Install package from other source
+                        </Button>
+                    </ButtonToolbar>
+                    <FirstInstallDialog />
+                    <RemoveEnvironmentDialog />
+                    <InstallPackageDialog />
+                    <ToolchainSourceDialog />
+                    <InstallDirDialog />
+                </>
+            )}
         </div>
     );
 };

--- a/src/Manager/PlatformInstructions.jsx
+++ b/src/Manager/PlatformInstructions.jsx
@@ -42,6 +42,8 @@ import Alert from 'react-bootstrap/Alert';
 const isLinux = process.platform === 'linux';
 const isWindows = process.platform === 'win32';
 
+export const enableLinux = false;
+
 export const OnlineDocs = ({ label }) => (
     <a
         target="_blank"
@@ -62,6 +64,7 @@ export default () => {
     const [isSnapAvailable, setSnapAvailable] = useState(true);
 
     useEffect(() => {
+        if (!enableLinux || !isLinux) return;
         try {
             execSync('which snap');
         } catch (err) {
@@ -72,10 +75,11 @@ export default () => {
     return (
         <>
             <Alert variant="warning">
-                <b>
-                    Support for {isLinux ? 'Linux' : 'macOS'} is experimental.
-                </b>{' '}
-                For instructions on how to manually set up an environment on
+                {isLinux && (
+                    <b>Linux is currently not supported by this app.</b>
+                )}
+                {isLinux || <b>Support for macOS is experimental.</b>} For
+                instructions on how to manually set up an environment on your
                 your machine, please read the online{' '}
                 <OnlineDocs label="documentation" />.
             </Alert>


### PR DESCRIPTION
Due to the limitations of the current solution of the toolchain package for linux the support for it in toolchain manager shall be disabled for now.