### PR TITLE
Fix cmake configuration issue on macOS

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,5 @@
 ## Version 0.8.2
-- Fixed cmake configuration issue on macOS
+- Fixed cmake configuration issue on macOS #66
 - Minor style update
 
 ## Version 0.8.1

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Version 0.8.2
+- Fixed cmake configuration issue on macOS
+- Minor style update
+
 ## Version 0.8.1
 - Fixed source code link
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-toolchain-manager",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Install and manage tools to develop with the nRF Connect SDK (NCS)",
   "displayName": "Toolchain Manager",
   "repository": {

--- a/src/Manager/Environment/environmentEffects.js
+++ b/src/Manager/Environment/environmentEffects.js
@@ -312,6 +312,7 @@ export const cloneNcs = (
                     .pop();
                 env.PATH = `${toolchainDir}/bin:${remote.process.env.PATH}`;
                 env.GIT_EXEC_PATH = `${toolchainDir}/Cellar/git/${gitversion}/libexec/git-core`;
+                env.HOME = `${remote.process.env.HOME}`;
 
                 ncsMgr = spawn(
                     `${toolchainDir}/ncsmgr/ncsmgr`,

--- a/src/style.scss
+++ b/src/style.scss
@@ -44,6 +44,8 @@
 
 .core19-main-container {
     @include scrollbars-helper($gray-100, $gray-400, $gray-200);
+    margin: 0 !important;
+    padding: 1rem;
 }
 
 .carousel-inner {


### PR DESCRIPTION
This PR on macOS fixes the missing `~/.cmake/packages/...` after the SDK repositories are cloned. The issue is caused by missing HOME environment variable in electron's sandboxed child process.

Already installed environments can also be fixed just by _Update SDK_ submenu command, which will execute the same script.