### PR TITLE
Dialog and instructions to remove directories that would block installation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Version 0.9.0
+- Added dialog and instructions to remove directories that would block installation #67
+- Disabled First steps screen during installation #67
+
 ## Version 0.8.2
 - Fixed cmake configuration issue on macOS #66
 - Minor style update

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-toolchain-manager",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Install and manage tools to develop with the nRF Connect SDK (NCS)",
   "displayName": "Toolchain Manager",
   "repository": {

--- a/src/Manager/Environment/ShowFirstSteps.jsx
+++ b/src/Manager/Environment/ShowFirstSteps.jsx
@@ -40,7 +40,7 @@ import { useDispatch } from 'react-redux';
 import { selectEnvironment, showFirstSteps } from '../managerReducer';
 import Button from './Button';
 import environmentPropType from './environmentPropType';
-import { isOnlyAvailable, version } from './environmentReducer';
+import { isInstalled, isOnlyAvailable, version } from './environmentReducer';
 
 const ShowFirstSteps = ({ environment }) => {
     const dispatch = useDispatch();
@@ -56,6 +56,7 @@ const ShowFirstSteps = ({ environment }) => {
             label="First steps to build"
             title="Show how to build a sample project"
             variant="secondary"
+            disabled={!isInstalled(environment)}
         />
     );
 };

--- a/src/Manager/Environment/environmentEffects.js
+++ b/src/Manager/Environment/environmentEffects.js
@@ -398,7 +398,7 @@ const confirmRemoveDir = dir => dispatch =>
         showReduxConfirmDialog({
             title: 'Inconsistent directory structure',
             content:
-                `\`${dir}\` directory blocks installation, it must be removed.\n\n` +
+                `\`${dir}\` directory blocks installation, it should be removed.\n\n` +
                 'If this directory is part of manually installed nRF Connect SDK environment, ' +
                 'consider changing the installation directory in SETTINGS.\n\n' +
                 'If this directory is leftover of an incorrect installation, click _Remove_.\n\n' +

--- a/src/Manager/Environment/environmentEffects.js
+++ b/src/Manager/Environment/environmentEffects.js
@@ -75,6 +75,7 @@ import {
     startRemoving,
 } from './environmentReducer';
 import { updateConfigFile } from './segger';
+import { showReduxConfirmDialogAction } from '../../ReduxConfirmDialog/reduxConfirmDialogReducer';
 
 const sudo = remote.require('sudo-prompt');
 const { spawn: remoteSpawn } = remote.require('child_process');
@@ -382,6 +383,62 @@ export const cloneNcs = (
     );
 };
 
+const showReduxConfirmDialog = ({ ...args }) => dispatch =>
+    new Promise((resolve, reject) => {
+        dispatch(
+            showReduxConfirmDialogAction({
+                callback: err => (err ? reject() : resolve()),
+                ...args,
+            })
+        );
+    });
+
+const confirmRemoveDir = dir => dispatch =>
+    dispatch(
+        showReduxConfirmDialog({
+            title: 'Inconsistent directory structure',
+            content:
+                `\`${dir}\` directory blocks installation, it must be removed.\n\n` +
+                'If this directory is part of manually installed nRF Connect SDK environment, ' +
+                'consider changing the installation directory in SETTINGS.\n\n' +
+                'If this directory is leftover of an incorrect installation, click _Remove_.\n\n' +
+                'Should you intend to manually remedy the issue, click _Open folder_. ' +
+                'Make sure hidden items are visible.',
+            confirmLabel: 'Remove',
+            onOptional: () => remote.shell.showItemInFolder(dir),
+            optionalLabel: 'Open folder',
+        })
+    );
+
+const ensureCleanTargetDir = toolchainDir => async dispatch => {
+    let dir = toolchainDir;
+    let toBeDeleted = null;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+        const westdir = path.resolve(dir, '.west');
+        if (fs.existsSync(westdir)) {
+            toBeDeleted = westdir;
+            break;
+        }
+        const parent = path.dirname(dir);
+        if (parent === dir) {
+            break;
+        }
+        dir = parent;
+    }
+    if (toBeDeleted) {
+        try {
+            await dispatch(confirmRemoveDir(toBeDeleted));
+            await dispatch(removeDir(toBeDeleted));
+        } catch (err) {
+            throw new Error(
+                `${toBeDeleted} must be removed to continue installation`
+            );
+        }
+        await dispatch(ensureCleanTargetDir(toolchainDir));
+    }
+};
+
 export const install = (
     { version, toolchains },
     justUpdate
@@ -404,29 +461,23 @@ export const install = (
     }
     setHasInstalledAnNcs();
 
-    await dispatch(installToolchain(version, toolchain, toolchainDir));
-    await dispatch(cloneNcs(version, toolchainDir, justUpdate));
+    try {
+        await dispatch(ensureCleanTargetDir(toolchainDir));
+        await dispatch(installToolchain(version, toolchain, toolchainDir));
+        await dispatch(cloneNcs(version, toolchainDir, justUpdate));
+    } catch (error) {
+        dispatch(showErrorDialog(`${error.message || error}`));
+        sendErrorReport(error.message || error);
+    }
 };
 
-export const remove = ({ toolchainDir, version }) => async dispatch => {
-    logger.info(`Removing ${version} at ${toolchainDir}`);
-    sendUsageData(EventAction.REMOVE_TOOLCHAIN, `${version}`);
-
-    const toBeDeletedDir = path.resolve(
-        toolchainDir,
-        '..',
-        '..',
-        'toBeDeleted'
-    );
-    dispatch(startRemoving(version));
-
-    const srcDir = path.dirname(toolchainDir);
+export const removeDir = srcDir => async dispatch => {
     let renameOfDirSuccessful = false;
     try {
+        const toBeDeletedDir = path.resolve(srcDir, '..', 'toBeDeleted');
         await fse.move(srcDir, toBeDeletedDir, { overwrite: true });
         renameOfDirSuccessful = true;
         await fse.remove(toBeDeletedDir);
-        logger.info(`Finish removing ${version} at ${toolchainDir}`);
     } catch (error) {
         const [, , message] = `${error}`.split(/[:,] /);
         const errorMsg =
@@ -436,7 +487,17 @@ export const remove = ({ toolchainDir, version }) => async dispatch => {
         dispatch(showErrorDialog(errorMsg));
         sendErrorReport(errorMsg);
     }
-    if (renameOfDirSuccessful) {
+    return renameOfDirSuccessful;
+};
+
+export const remove = ({ toolchainDir, version }) => async dispatch => {
+    logger.info(`Removing ${version} at ${toolchainDir}`);
+    sendUsageData(EventAction.REMOVE_TOOLCHAIN, `${version}`);
+
+    dispatch(startRemoving(version));
+
+    if (await dispatch(removeDir(path.dirname(toolchainDir)))) {
+        logger.info(`Finished removing ${version} at ${toolchainDir}`);
         dispatch(removeEnvironment(version));
     }
 
@@ -454,16 +515,20 @@ export const installPackage = urlOrFilePath => async dispatch => {
         sendErrorReport(errorMsg);
         return;
     }
-    const version = match[1];
-    const toolchainDir = path.resolve(installDir(), version, 'toolchain');
-    fse.mkdirpSync(toolchainDir);
-
-    dispatch(
-        addLocallyExistingEnvironment(version, toolchainDir, false, false)
-    );
-    dispatch(startInstallToolchain(version));
 
     try {
+        const version = match[1];
+        const toolchainDir = path.resolve(installDir(), version, 'toolchain');
+
+        await dispatch(ensureCleanTargetDir(toolchainDir));
+
+        fse.mkdirpSync(toolchainDir);
+
+        dispatch(
+            addLocallyExistingEnvironment(version, toolchainDir, false, false)
+        );
+        dispatch(startInstallToolchain(version));
+
         const filePath = fse.existsSync(urlOrFilePath)
             ? urlOrFilePath
             : await dispatch(download(version, { uri: urlOrFilePath }));

--- a/src/Manager/Environment/environmentEffects.js
+++ b/src/Manager/Environment/environmentEffects.js
@@ -398,7 +398,7 @@ const confirmRemoveDir = dir => dispatch =>
         showReduxConfirmDialog({
             title: 'Inconsistent directory structure',
             content:
-                `The \`${dir}\` directory blocks installation, it should be removed.\n\n` +
+                `The \`${dir}\` directory blocks installation, and should be removed.\n\n` +
                 'If this directory is part of manually installed nRF Connect SDK environment, ' +
                 'consider changing the installation directory in SETTINGS.\n\n' +
                 'If this directory is left over from an incorrect installation, click _Remove_.\n\n' +

--- a/src/Manager/Environment/environmentEffects.js
+++ b/src/Manager/Environment/environmentEffects.js
@@ -398,10 +398,10 @@ const confirmRemoveDir = dir => dispatch =>
         showReduxConfirmDialog({
             title: 'Inconsistent directory structure',
             content:
-                `\`${dir}\` directory blocks installation, it should be removed.\n\n` +
+                `The \`${dir}\` directory blocks installation, it should be removed.\n\n` +
                 'If this directory is part of manually installed nRF Connect SDK environment, ' +
                 'consider changing the installation directory in SETTINGS.\n\n' +
-                'If this directory is leftover of an incorrect installation, click _Remove_.\n\n' +
+                'If this directory is left over from an incorrect installation, click _Remove_.\n\n' +
                 'Should you intend to manually remedy the issue, click _Open folder_. ' +
                 'Make sure hidden items are visible.',
             confirmLabel: 'Remove',

--- a/src/Manager/Manager.jsx
+++ b/src/Manager/Manager.jsx
@@ -48,6 +48,7 @@ import NrfCard from '../NrfCard/NrfCard';
 import ToolchainSourceDialog from '../ToolchainSource/ToolchainSourceDialog';
 import { EventAction, sendUsageData } from '../usageDataActions';
 import Environment from './Environment/Environment';
+import ReduxConfirmDialog from '../ReduxConfirmDialog/ReduxConfirmDialog';
 import RemoveEnvironmentDialog from './Environment/RemoveEnvironmentDialog';
 import initEnvironments from './initEnvironments';
 import {
@@ -142,6 +143,7 @@ export default props => {
                     <InstallPackageDialog />
                     <ToolchainSourceDialog />
                     <InstallDirDialog />
+                    <ReduxConfirmDialog />
                 </>
             )}
         </div>

--- a/src/ReduxConfirmDialog/ReduxConfirmDialog.jsx
+++ b/src/ReduxConfirmDialog/ReduxConfirmDialog.jsx
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015 - 2018, Nordic Semiconductor ASA
+/* Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -34,19 +34,53 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { combineReducers } from 'redux';
-import firstInstall from './FirstInstall/firstInstallReducer';
-import installDir from './InstallDir/installDirReducer';
-import manager from './Manager/managerReducer';
-import toolchainSource from './ToolchainSource/toolchainSourceReducer';
-import reduxConfirmDialog from './ReduxConfirmDialog/reduxConfirmDialogReducer';
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import ReactMarkdown from 'react-markdown';
 
-const rootReducer = combineReducers({
-    firstInstall,
-    installDir,
-    manager,
-    toolchainSource,
-    reduxConfirmDialog,
-});
+import ConfirmationDialog from '../ConfirmationDialog/ConfirmationDialog';
+import {
+    hideReduxConfirmDialogAction,
+    reduxConfirmDialogSelector,
+} from './reduxConfirmDialogReducer';
 
-export default rootReducer;
+export default () => {
+    const dispatch = useDispatch();
+    const {
+        title,
+        content,
+        callback,
+        confirmLabel,
+        cancelLabel,
+        onOptional,
+        optionalLabel,
+    } = useSelector(reduxConfirmDialogSelector);
+
+    return (
+        <ConfirmationDialog
+            isVisible={!!callback}
+            title={title}
+            onCancel={() => {
+                dispatch(hideReduxConfirmDialogAction());
+                callback(true);
+            }}
+            onConfirm={() => {
+                dispatch(hideReduxConfirmDialogAction());
+                callback();
+            }}
+            confirmLabel={confirmLabel}
+            cancelLabel={cancelLabel}
+            onOptional={
+                onOptional
+                    ? () => {
+                          dispatch(hideReduxConfirmDialogAction());
+                          onOptional();
+                      }
+                    : undefined
+            }
+            optionalLabel={optionalLabel}
+        >
+            <ReactMarkdown>{content}</ReactMarkdown>
+        </ConfirmationDialog>
+    );
+};

--- a/src/ReduxConfirmDialog/reduxConfirmDialogReducer.js
+++ b/src/ReduxConfirmDialog/reduxConfirmDialogReducer.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015 - 2018, Nordic Semiconductor ASA
+/* Copyright (c) 2015 - 2020, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -34,19 +34,32 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { combineReducers } from 'redux';
-import firstInstall from './FirstInstall/firstInstallReducer';
-import installDir from './InstallDir/installDirReducer';
-import manager from './Manager/managerReducer';
-import toolchainSource from './ToolchainSource/toolchainSourceReducer';
-import reduxConfirmDialog from './ReduxConfirmDialog/reduxConfirmDialogReducer';
-
-const rootReducer = combineReducers({
-    firstInstall,
-    installDir,
-    manager,
-    toolchainSource,
-    reduxConfirmDialog,
+const SHOW_REDUX_CONFIRM_DIALOG = 'SHOW_REDUX_CONFIRM_DIALOG';
+export const showReduxConfirmDialogAction = ({ ...args }) => ({
+    type: SHOW_REDUX_CONFIRM_DIALOG,
+    ...args,
+});
+const HIDE_REDUX_CONFIRM_DIALOG = 'HIDE_REDUX_CONFIRM_DIALOG';
+export const hideReduxConfirmDialogAction = () => ({
+    type: HIDE_REDUX_CONFIRM_DIALOG,
 });
 
-export default rootReducer;
+const initialState = {
+    callback: null,
+    title: null,
+    content: null,
+    confirmLabel: null,
+};
+
+export default (state = initialState, { type, ...action }) => {
+    switch (type) {
+        case SHOW_REDUX_CONFIRM_DIALOG:
+            return { ...state, ...action };
+        case HIDE_REDUX_CONFIRM_DIALOG:
+            return initialState;
+        default:
+            return state;
+    }
+};
+
+export const reduxConfirmDialogSelector = ({ app }) => app.reduxConfirmDialog;


### PR DESCRIPTION
This PR tries to prevent that the west clone procedure breaks, which would in case a higher level `.west` folder exists.
Prior installation procedure all parent folders are checked and the user is informed and instructed to remove these folders.

![image](https://user-images.githubusercontent.com/26139379/102461630-efcdd880-4048-11eb-98c6-43d8ecec8a4b.png)

The first steps screen is also disabled during installation since it breaks the installation workflow and introduces further inconsistencies.