### PR TITLE
Remove changelog entry

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,3 @@
-## Unreleased
-### Changed
-- Updated to pc-nrfconnect-shared 4.18.0
-- Updated API call to send usage data, replacing `sendEvent` by `sendUsageData`
-
 ## Version 0.9.1
 - Fixed opening SEGGER Embedded Studio on macOS #70
 - Prevented using non-default base path on macOS #70


### PR DESCRIPTION
Because it does not describe a change that is visible to the users.