### PR TITLE
Fix path on macOS

### DIFF
--- a/src/Manager/Environment/EnvironmentMenu.jsx
+++ b/src/Manager/Environment/EnvironmentMenu.jsx
@@ -95,7 +95,7 @@ const openTerminal = {
         );
         const gitversion = readdirSync(`${toolchainDir}/Cellar/git`).pop();
         const env = [
-            `export PATH=${toolchainDir}/bin:$PATH`,
+            `export PATH=${toolchainDir}/bin:/usr/local/bin:$PATH`,
             `export GIT_EXEC_PATH=${toolchainDir}/Cellar/git/${gitversion}/libexec/git-core`,
             'export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb',
             `export GNUARMEMB_TOOLCHAIN_PATH=${toolchainDir}`,


### PR DESCRIPTION
This fixes [NCP-3761](https://projecttools.nordicsemi.no/jira/browse/NCP-3761):

Strangely, /usr/local/bin is not in the PATH by default when we open
a terminal from an application. But it being in the path is expected
for many cases, e.g. when nrfjprog is placed there. homebrew is usually
also found in /usr/local/bin