### PR TITLE
fix: init environments at app start only

### DIFF
--- a/src/Manager/Manager.tsx
+++ b/src/Manager/Manager.tsx
@@ -59,9 +59,6 @@ import {
 import PlatformInstructions, { enableLinux } from './PlatformInstructions';
 
 const Environments = () => {
-    const dispatch = useDispatch();
-    useEffect(() => initEnvironments(dispatch), [dispatch]);
-
     const masterVisible = useSelector(isMasterVisible);
     const allEnvironments = useSelector(environmentsByVersion);
     const environments = allEnvironments.filter(({ version, isInstalled }) =>
@@ -97,6 +94,7 @@ const Environments = () => {
 
 export default () => {
     const dispatch = useDispatch();
+    useEffect(() => initEnvironments(dispatch), [dispatch]);
     const showingFirstSteps = useSelector(isShowingFirstSteps);
 
     if (showingFirstSteps) {


### PR DESCRIPTION
Fixes [this](https://trello.com/c/E5HxyMfO/214-while-installing-a-toolchain-clicking-on-first-steps-to-build-hides-the-installation-progress)