### PR TITLE
Allow non-semver versions

### DIFF
--- a/src/Manager/Manager.tsx
+++ b/src/Manager/Manager.tsx
@@ -15,10 +15,7 @@ import InstallDirDialog from '../InstallDir/InstallDirDialog';
 import InstallPackageDialog from '../InstallPackageDialog/InstallPackageDialog';
 import NrfCard from '../NrfCard/NrfCard';
 import ReduxConfirmDialog from '../ReduxConfirmDialog/ReduxConfirmDialog';
-import {
-    isMasterVisible,
-    isOlderEnvironmentsHidden,
-} from '../Settings/settingsSlice';
+import { isOlderEnvironmentsHidden } from '../Settings/settingsSlice';
 import ToolchainSourceDialog from '../ToolchainSource/ToolchainSourceDialog';
 import EventAction from '../usageDataActions';
 import Environment from './Environment/Environment';
@@ -33,30 +30,17 @@ import PlatformInstructions, { enableLinux } from './PlatformInstructions';
 import { filterEnvironments } from './versionFilter';
 
 const Environments = () => {
-    const masterVisible = useSelector(isMasterVisible);
     const hideOlderAndPreRelease = useSelector(isOlderEnvironmentsHidden);
     const allEnvironments = useSelector(environmentsByVersion);
 
-    const filteredEnvironments = hideOlderAndPreRelease
+    const environments = hideOlderAndPreRelease
         ? filterEnvironments(allEnvironments)
         : allEnvironments;
-
-    const environments = filteredEnvironments.filter(
-        ({ version, isInstalled }) =>
-            version === 'master' ? isInstalled || masterVisible : true
-    );
 
     if (environments.length === 0) {
         return (
             <NrfCard>
                 <p>There are no environments available for installation.</p>
-                {allEnvironments.length > 0 && !masterVisible && (
-                    <p>
-                        You can enable unstable environments under{' '}
-                        <span className="mdi mdi-settings" />
-                        Settings.
-                    </p>
-                )}
             </NrfCard>
         );
     }

--- a/src/Manager/versionFilter.test.ts
+++ b/src/Manager/versionFilter.test.ts
@@ -47,4 +47,12 @@ describe('filter versions to keep last 3 minor versions and installed environmen
         const filtered = filter(versions);
         expect(filtered.map(v => v.version).join(', ')).toEqual(sampleExpected);
     });
+
+    it('do not filter non-semver versions', () => {
+        const versions = ['1.2.2', '1.2.3', 'master'];
+        const environments = versions.map(mapToEnvironment);
+
+        const filtered = filterEnvironments(environments);
+        expect(filtered.length).toBe(3);
+    });
 });

--- a/src/Manager/versionFilter.ts
+++ b/src/Manager/versionFilter.ts
@@ -34,13 +34,16 @@ export const filterEnvironments = (
 };
 
 const hash = (version: string) =>
-    `${semver.major(version)}.${semver.minor(version)}`;
+    semver.valid(version)
+        ? `${semver.major(version)}.${semver.minor(version)}`
+        : version;
 
 const isReleasedOrPreRelease = (version: string, versions: string[]) => {
+    if (semver.valid(version) === null) return true;
     const isPrerelease = (semver.prerelease(version)?.length ?? 0) > 0 ?? false;
 
     const hasRelease = versions.some(
-        v => semver.diff(v, version) === 'prerelease'
+        v => semver.valid(v) && semver.diff(v, version) === 'prerelease'
     );
 
     return !isPrerelease || !hasRelease;

--- a/src/Settings/Settings.tsx
+++ b/src/Settings/Settings.tsx
@@ -22,10 +22,8 @@ import {
     toolchainRootUrl,
 } from '../ToolchainSource/toolchainSourceSlice';
 import {
-    isMasterVisible,
     isOlderEnvironmentsHidden,
     isVsCodeVisible,
-    showMasterEnvironment,
     showOlderEnvironments,
     showVsCode,
 } from './settingsSlice';
@@ -34,7 +32,6 @@ export default () => {
     const dispatch = useDispatch();
     const installDir = useSelector(currentInstallDir);
     const disabled = process.platform === 'darwin';
-    const masterVisible = useSelector(isMasterVisible);
     const vsCodeVisible = useSelector(isVsCodeVisible);
     const toolchainUrl = useSelector(toolchainRootUrl);
     const olderEnvironmentsHidden = useSelector(isOlderEnvironmentsHidden);
@@ -55,32 +52,6 @@ export default () => {
                         >
                             Select directory
                         </Button>
-                    </Col>
-                </Row>
-
-                <Row className="settings-info mt-4">
-                    <Col>
-                        <Form.Group controlId="toggleMaster">
-                            <div className="d-flex">
-                                <Toggle
-                                    isToggled={masterVisible}
-                                    labelRight
-                                    onToggle={() =>
-                                        dispatch(
-                                            showMasterEnvironment(
-                                                !masterVisible
-                                            )
-                                        )
-                                    }
-                                    label="Show unstable (master branch) environment"
-                                />
-                            </div>
-                            <Form.Text className="text-muted">
-                                Note that the unstable environment is not
-                                regularly updated, and its toolchain is likely
-                                not well tested.
-                            </Form.Text>
-                        </Form.Group>
                     </Col>
                 </Row>
 

--- a/src/Settings/settingsSlice.ts
+++ b/src/Settings/settingsSlice.ts
@@ -7,22 +7,18 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import {
     persistedHideOlderEnvironments,
-    persistedShowMaster,
     persistedShowVsCode,
     setPersistedHideOlderEnvironments,
-    setPersistedShowMaster,
     setPersistedShowVsCode,
 } from '../persistentStore';
 import { RootState } from '../state';
 
 export interface SettingsState {
-    isMasterVisible: boolean;
     isVsCodeVisible: boolean;
     isOlderEnvironmentsHidden: boolean;
 }
 
 const initialState: SettingsState = {
-    isMasterVisible: persistedShowMaster(),
     isVsCodeVisible: persistedShowVsCode(),
     isOlderEnvironmentsHidden: persistedHideOlderEnvironments(),
 };
@@ -31,10 +27,6 @@ const slice = createSlice({
     name: 'settings',
     initialState,
     reducers: {
-        showMasterEnvironment: (state, action: PayloadAction<boolean>) => {
-            setPersistedShowMaster(action.payload);
-            state.isMasterVisible = action.payload;
-        },
         showVsCode: (state, action: PayloadAction<boolean>) => {
             setPersistedShowVsCode(action.payload);
             state.isVsCodeVisible = action.payload;
@@ -48,11 +40,8 @@ const slice = createSlice({
 
 export const {
     reducer,
-    actions: { showMasterEnvironment, showVsCode, showOlderEnvironments },
+    actions: { showVsCode, showOlderEnvironments },
 } = slice;
-
-export const isMasterVisible = ({ app: { settings } }: RootState) =>
-    settings.isMasterVisible;
 
 export const isVsCodeVisible = ({ app: { settings } }: RootState) =>
     settings.isVsCodeVisible;


### PR DESCRIPTION
Allow toolchain manager to have non-semver versions of environments. 

![image](https://user-images.githubusercontent.com/1006193/133092166-8e42c608-aefd-47cf-8f92-c87191ff9b7f.png)

Removed hiding of master as it is no longer available for mac and windows.