### PR TITLE
style: use a custom className instead of overwriting a shared one

### DIFF
--- a/src/Manager/Manager.tsx
+++ b/src/Manager/Manager.tsx
@@ -90,6 +90,7 @@ export default () => {
                     (evt.dataTransfer.files[0] || {}).path;
                 dispatch(showInstallPackageDialog(pkg));
             }}
+            className="toolchain-manager-main-window"
         >
             <PlatformInstructions />
             {(process.platform !== 'linux' || enableLinux) && (

--- a/src/Settings/Settings.tsx
+++ b/src/Settings/Settings.tsx
@@ -34,7 +34,7 @@ export default () => {
     const olderEnvironmentsHidden = useSelector(isOlderEnvironmentsHidden);
 
     return (
-        <div>
+        <div className="toolchain-manager-main-window">
             <NrfCard>
                 <Row className="settings-info">
                     <Col className="ml-3">

--- a/src/style.scss
+++ b/src/style.scss
@@ -36,7 +36,7 @@
 
 @import "~pc-nrfconnect-shared/styles";
 
-.core19-app-content .core19-main-and-log .core19-main-container .carousel-inner {
+.toolchain-manager-main-window {
     height: initial;
     max-width: 800px;
     margin: auto;
@@ -87,7 +87,8 @@ code {
     font-size: 1em;
 }
 
-p, li {
+p,
+li {
     margin-bottom: 0.5rem;
 }
 


### PR DESCRIPTION
Used a custom className instead of using a shared one. This will make it so the About pane is not restricted in width.

Changed it due to a new feature from shared which would otherwise squish the cards in the About pane: https://github.com/NordicSemiconductor/pc-nrfconnect-shared/pull/200

## Checklist

- [x] Ensure all user facing text is spell checked.
- [ ] Bump version in package.json
- [ ] Update changelog
- [ ] Write tests if needed
