### PR TITLE
Fix/handle extension not installed

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 0.10.3 - 2022-01-19
+### Fixed
+- VS Code Extensions which failed to install were not detected in some cases.
+
 ## 0.10.2 - 2022-01-10
 ### Added
 - Instructions for installing Intel version of VS Code and JLink.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-toolchain-manager",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Install and manage tools to develop with the nRF Connect SDK (NCS)",
   "displayName": "Toolchain Manager",
   "repository": {

--- a/src/VsCodeDialog/vscode.ts
+++ b/src/VsCodeDialog/vscode.ts
@@ -199,10 +199,10 @@ const spawnAsync = (cmd: string, params?: string[]) => {
         });
 
         codeProcess.on('close', (code, signal) => {
+            if (stderr) console.log(stderr);
             if (code === 0 && signal === null) {
                 return resolve(stdout);
             }
-            if (stderr) console.log(stderr);
             return reject();
         });
     });

--- a/src/VsCodeDialog/vscode.ts
+++ b/src/VsCodeDialog/vscode.ts
@@ -115,6 +115,12 @@ export const installExtensions =
                 dispatch(installExtension(extension.identifier));
         });
 
+const onExtensionInstallFailed =
+    (identifier: string) => (dispatch: Dispatch) => {
+        dispatch(installExtensionFailed(identifier));
+        logger.error(`Failed to install extension ${identifier}`);
+    };
+
 const installExtension = (identifier: string) => async (dispatch: Dispatch) => {
     try {
         dispatch(startInstallingExtension(identifier));
@@ -123,13 +129,9 @@ const installExtension = (identifier: string) => async (dispatch: Dispatch) => {
         if (installedExtensions.map(e => e.identifier).includes(identifier)) {
             dispatch(installedExtension(identifier));
             logger.info(`Installed extension ${identifier}`);
-        } else {
-            dispatch(installExtensionFailed(identifier));
-            logger.error(`Failed to install extension ${identifier}`);
-        }
+        } else onExtensionInstallFailed(identifier);
     } catch {
-        dispatch(installExtensionFailed(identifier));
-        logger.error(`Failed to install extension ${identifier}`);
+        onExtensionInstallFailed(identifier);
     }
 };
 

--- a/src/VsCodeDialog/vscode.ts
+++ b/src/VsCodeDialog/vscode.ts
@@ -126,7 +126,7 @@ const installExtension = (identifier: string) => async (dispatch: Dispatch) => {
         dispatch(startInstallingExtension(identifier));
         await spawnAsync('code', ['--install-extension', identifier]);
         const installedExtensions = await listInstalledExtensions();
-        if (installedExtensions.map(e => e.identifier).includes(identifier)) {
+        if (installedExtensions.some(e => e.identifier === identifier)) {
             dispatch(installedExtension(identifier));
             logger.info(`Installed extension ${identifier}`);
         } else onExtensionInstallFailed(identifier);

--- a/src/VsCodeDialog/vscode.ts
+++ b/src/VsCodeDialog/vscode.ts
@@ -119,8 +119,14 @@ const installExtension = (identifier: string) => async (dispatch: Dispatch) => {
     try {
         dispatch(startInstallingExtension(identifier));
         await spawnAsync('code', ['--install-extension', identifier]);
-        dispatch(installedExtension(identifier));
-        logger.info(`Installed extension ${identifier}`);
+        const installedExtensions = await listInstalledExtensions();
+        if (installedExtensions.map(e => e.identifier).includes(identifier)) {
+            dispatch(installedExtension(identifier));
+            logger.info(`Installed extension ${identifier}`);
+        } else {
+            dispatch(installExtensionFailed(identifier));
+            logger.error(`Failed to install extension ${identifier}`);
+        }
     } catch {
         dispatch(installExtensionFailed(identifier));
         logger.error(`Failed to install extension ${identifier}`);


### PR DESCRIPTION
Code returns code 0 and write to stderr when extensions fail to install in certain situations (VS Code outdated and cannot find/install extensions).
Stderr is also used for warnings or unrelated implementation logs, which would require string comparisons to check for relevant errors.

We now manually check for the install status of extensions.

## Checklist

- [x] Ensure all user facing text is spell checked.
- [x] Bump version in package.json
- [x] Update changelog
- [ ] Write tests if needed
