### PR TITLE
Fix required engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,66 +1,66 @@
 {
-  "name": "pc-nrfconnect-toolchain-manager",
-  "version": "0.10.3",
-  "description": "Install and manage tools to develop with the nRF Connect SDK (NCS)",
-  "displayName": "Toolchain Manager",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/NordicSemiconductor/pc-nrfconnect-toolchain-manager.git"
-  },
-  "author": "Nordic Semiconductor ASA",
-  "license": "SEE LICENSE IN LICENSE",
-  "engines": {
-    "nrfconnect": "^3.9.2"
-  },
-  "main": "dist/bundle.js",
-  "files": [
-    "dist/",
-    "resources/icon.*",
-    "LICENSE"
-  ],
-  "scripts": {
-    "dev": "nrfconnect-scripts build-watch",
-    "webpack": "nrfconnect-scripts build-dev",
-    "build": "nrfconnect-scripts build-prod",
-    "nordic-publish": "nrfconnect-scripts nordic-publish",
-    "lint": "nrfconnect-scripts lint src",
-    "lint-init": "nrfconnect-scripts lint-init",
-    "lintfix": "nrfconnect-scripts lint --fix src",
-    "test": "nrfconnect-scripts test",
-    "test-watch": "nrfconnect-scripts test --watch",
-    "clean": "npm run clean-dist && npm run clean-modules",
-    "clean-dist": "rimraf dist",
-    "clean-modules": "rimraf \"node_modules/!(rimraf|.bin)\""
-  },
-  "devDependencies": {
-    "@reduxjs/toolkit": "1.6.1",
-    "@testing-library/react": "^12.1.1",
-    "@types/fs-extra": "^9.0.12",
-    "@types/react-dom": "^17.0.9",
-    "@types/react-redux": "^7.1.18",
-    "@types/semver": "^7.3.8",
-    "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v5.10.0",
-    "@types/node": "^14.14.33",
-    "electron": "^13.5.1",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-redux": "7.2.0",
-    "sudo-prompt": "^9.2.1"
-  },
-  "dependencies": {
-    "electron-store": "^3.2.0",
-    "extract-zip": "^2.0.1",
-    "fs-extra": "^8.1.0",
-    "semver": "^7.1.1"
-  },
-  "bundledDependencies": [
-    "electron-store",
-    "extract-zip",
-    "fs-extra",
-    "semver"
-  ],
-  "eslintConfig": {
-    "extends": "./node_modules/pc-nrfconnect-shared/config/eslintrc.json"
-  },
-  "prettier": "./node_modules/pc-nrfconnect-shared/config/prettier.config.js"
+    "name": "pc-nrfconnect-toolchain-manager",
+    "version": "0.10.3",
+    "description": "Install and manage tools to develop with the nRF Connect SDK (NCS)",
+    "displayName": "Toolchain Manager",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/NordicSemiconductor/pc-nrfconnect-toolchain-manager.git"
+    },
+    "author": "Nordic Semiconductor ASA",
+    "license": "SEE LICENSE IN LICENSE",
+    "engines": {
+        "nrfconnect": "^3.9.2"
+    },
+    "main": "dist/bundle.js",
+    "files": [
+        "dist/",
+        "resources/icon.*",
+        "LICENSE"
+    ],
+    "scripts": {
+        "dev": "nrfconnect-scripts build-watch",
+        "webpack": "nrfconnect-scripts build-dev",
+        "build": "nrfconnect-scripts build-prod",
+        "nordic-publish": "nrfconnect-scripts nordic-publish",
+        "lint": "nrfconnect-scripts lint src",
+        "lint-init": "nrfconnect-scripts lint-init",
+        "lintfix": "nrfconnect-scripts lint --fix src",
+        "test": "nrfconnect-scripts test",
+        "test-watch": "nrfconnect-scripts test --watch",
+        "clean": "npm run clean-dist && npm run clean-modules",
+        "clean-dist": "rimraf dist",
+        "clean-modules": "rimraf \"node_modules/!(rimraf|.bin)\""
+    },
+    "devDependencies": {
+        "@reduxjs/toolkit": "1.6.1",
+        "@testing-library/react": "^12.1.1",
+        "@types/fs-extra": "^9.0.12",
+        "@types/react-dom": "^17.0.9",
+        "@types/react-redux": "^7.1.18",
+        "@types/semver": "^7.3.8",
+        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v5.10.0",
+        "@types/node": "^14.14.33",
+        "electron": "^13.5.1",
+        "react": "16.13.1",
+        "react-dom": "16.13.1",
+        "react-redux": "7.2.0",
+        "sudo-prompt": "^9.2.1"
+    },
+    "dependencies": {
+        "electron-store": "^3.2.0",
+        "extract-zip": "^2.0.1",
+        "fs-extra": "^8.1.0",
+        "semver": "^7.1.1"
+    },
+    "bundledDependencies": [
+        "electron-store",
+        "extract-zip",
+        "fs-extra",
+        "semver"
+    ],
+    "eslintConfig": {
+        "extends": "./node_modules/pc-nrfconnect-shared/config/eslintrc.json"
+    },
+    "prettier": "./node_modules/pc-nrfconnect-shared/config/prettier.config.js"
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Nordic Semiconductor ASA",
   "license": "SEE LICENSE IN LICENSE",
   "engines": {
-    "nrfconnect": "^3.7.0"
+    "nrfconnect": "^3.9.2"
   },
   "main": "dist/bundle.js",
   "files": [


### PR DESCRIPTION
This app currently needs `shared` 5.10.0 and thus also needs at least 3.9.2 of the engine.