### PR TITLE
Remove outdated lint-init script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
         "build": "nrfconnect-scripts build-prod",
         "nordic-publish": "nrfconnect-scripts nordic-publish",
         "lint": "nrfconnect-scripts lint src",
-        "lint-init": "nrfconnect-scripts lint-init",
         "lintfix": "nrfconnect-scripts lint --fix src",
         "test": "nrfconnect-scripts test",
         "test-watch": "nrfconnect-scripts test --watch",


### PR DESCRIPTION
`lint-init` is not needed anymore. Remove the last reference to it.