### PR TITLE
Fix: Missing existing environments on Windows

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@
 -   On Windows previously installed SDK environments disappeared if users never
     changed the installation directory.
 
+### Known Issues
+
+-   When opening the Toolchain Manager for the first time after updating it it
+    sometimes just shows a white windows. On subsequent launches it works
+    normally.
+
 ## 1.0.0 - 2022-06-02
 
 ### Added

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Fixed
+
+-   On Windows previously installed SDK environments disappeared if users never
+    changed the installation directory.
+
 ## 1.0.0 - 2022-06-02
 
 ### Added

--- a/src/Manager/Manager.tsx
+++ b/src/Manager/Manager.tsx
@@ -27,6 +27,7 @@ import {
 } from '../VsCodeDialog/vscode';
 import VsCodeDialog from '../VsCodeDialog/VsCodeDialog';
 import { VsCodeStatus } from '../VsCodeDialog/vscodeSlice';
+import detectMultipleInstallDirs from './detectMultipleInstallDirs';
 import Environment from './Environment/Environment';
 import RemoveEnvironmentDialog from './Environment/RemoveEnvironmentDialog';
 import initEnvironments from './initEnvironments';
@@ -120,6 +121,7 @@ export default () => {
 };
 
 const initApp = (dispatch: Dispatch) => {
+    detectMultipleInstallDirs(dispatch);
     initEnvironments(dispatch);
     reportVsCodeStatus(dispatch);
 };

--- a/src/Manager/detectMultipleInstallDirs.ts
+++ b/src/Manager/detectMultipleInstallDirs.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { readdirSync } from 'fs';
+
+import { setInstallDir } from '../InstallDir/installDirSlice';
+import {
+    defaultInstallDir,
+    oldDefaultInstallDirOnWindows,
+    usesDefaultInstallDir,
+} from '../persistentStore';
+import { showReduxConfirmDialogAction } from '../ReduxConfirmDialog/reduxConfirmDialogSlice';
+import { Dispatch } from '../state';
+
+const filesIn = (dir: string) => {
+    try {
+        return readdirSync(dir);
+    } catch (error) {
+        return [];
+    }
+};
+
+const containsFiles = (dir: string) => filesIn(dir).length > 0;
+
+const showInstallDirConflictDialog = (oldDir: string, newDir: string) =>
+    showReduxConfirmDialogAction({
+        callback: () => {},
+        title: 'Old SDK environments found',
+        content:
+            `You have old SDK environments in the folder \`${oldDir}\` ` +
+            `and also already installed a new SDK environment in the folder ` +
+            `\`${newDir}\`.\n\n` +
+            `For now, only the new SDK environment will be visible as ` +
+            `installed environment. \n\n` +
+            `The old SDK environments will still be there and you can ` +
+            `continue to work with them, e.g. in VS Code. But if you want ` +
+            `to see and work with them again here in the Toolchain Manager ` +
+            `you first have to change the installation directory in the ` +
+            `settings back to \`${oldDir}\`. If you need to see the new ` +
+            `SDK toolchains here again, you can again switch the ` +
+            `installation directory to \`${newDir}\`.` +
+            `\n\n` +
+            `As an alternative, you can also install the old SDK ` +
+            `environments again in the folder \`${newDir}\` by clicking ` +
+            `“Install” next to them. But please note that any current ` +
+            `projects you have might reference the SDK environment in the ` +
+            `old folder \`${oldDir}\`.`,
+        hideCancel: true,
+    });
+
+export default (dispatch: Dispatch) => {
+    if (process.platform !== 'win32' || !usesDefaultInstallDir()) return;
+
+    const oldDefaultInstallDir = oldDefaultInstallDirOnWindows;
+    const newDefaultInstallDir = defaultInstallDir;
+
+    const oldDefaultInstallDirIsUsed = containsFiles(oldDefaultInstallDir);
+    const newDefaultInstallDirIsUsed = containsFiles(newDefaultInstallDir);
+
+    if (oldDefaultInstallDirIsUsed && newDefaultInstallDirIsUsed) {
+        dispatch(
+            showInstallDirConflictDialog(
+                oldDefaultInstallDir,
+                newDefaultInstallDir
+            )
+        );
+        dispatch(setInstallDir(newDefaultInstallDir));
+    }
+
+    if (oldDefaultInstallDirIsUsed && !newDefaultInstallDirIsUsed) {
+        dispatch(setInstallDir(oldDefaultInstallDir));
+    }
+
+    if (!oldDefaultInstallDirIsUsed && newDefaultInstallDirIsUsed) {
+        dispatch(setInstallDir(newDefaultInstallDir));
+    }
+};

--- a/src/ReduxConfirmDialog/ReduxConfirmDialog.tsx
+++ b/src/ReduxConfirmDialog/ReduxConfirmDialog.tsx
@@ -26,29 +26,40 @@ export default () => {
         optionalLabel,
     } = useSelector(reduxConfirmDialogSelector);
 
+    const cancelProps = {
+        cancelLabel,
+        onCancel: () => {
+            dispatch(hideReduxConfirmDialogAction());
+            callback ? callback(true) : undefined;
+        },
+    };
+
+    const confirmProps = {
+        confirmLabel,
+        onConfirm: () => {
+            dispatch(hideReduxConfirmDialogAction());
+            callback ? callback(false) : undefined;
+        },
+    };
+
+    const optionalProps = onOptional
+        ? {
+              optionalLabel,
+              onOptional: () => {
+                  dispatch(hideReduxConfirmDialogAction());
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- TypeScript does not conclude correctly that we already checked that onOptional is not undefined here
+                  onOptional!(false);
+              },
+          }
+        : {};
+
     return (
         <ConfirmationDialog
             isVisible={!!callback}
             title={title ?? ''}
-            onCancel={() => {
-                dispatch(hideReduxConfirmDialogAction());
-                callback ? callback(true) : undefined;
-            }}
-            onConfirm={() => {
-                dispatch(hideReduxConfirmDialogAction());
-                callback ? callback(false) : undefined;
-            }}
-            confirmLabel={confirmLabel}
-            cancelLabel={cancelLabel}
-            onOptional={
-                onOptional
-                    ? () => {
-                          dispatch(hideReduxConfirmDialogAction());
-                          onOptional(false);
-                      }
-                    : undefined
-            }
-            optionalLabel={optionalLabel}
+            {...confirmProps}
+            {...cancelProps}
+            {...optionalProps}
         >
             <ReactMarkdown>{content}</ReactMarkdown>
         </ConfirmationDialog>

--- a/src/ReduxConfirmDialog/ReduxConfirmDialog.tsx
+++ b/src/ReduxConfirmDialog/ReduxConfirmDialog.tsx
@@ -21,18 +21,21 @@ export default () => {
         content,
         callback,
         confirmLabel,
+        hideCancel,
         cancelLabel,
         onOptional,
         optionalLabel,
     } = useSelector(reduxConfirmDialogSelector);
 
-    const cancelProps = {
-        cancelLabel,
-        onCancel: () => {
-            dispatch(hideReduxConfirmDialogAction());
-            callback ? callback(true) : undefined;
-        },
-    };
+    const cancelProps = hideCancel
+        ? {}
+        : {
+              cancelLabel,
+              onCancel: () => {
+                  dispatch(hideReduxConfirmDialogAction());
+                  callback ? callback(true) : undefined;
+              },
+          };
 
     const confirmProps = {
         confirmLabel,

--- a/src/ReduxConfirmDialog/reduxConfirmDialogSlice.ts
+++ b/src/ReduxConfirmDialog/reduxConfirmDialogSlice.ts
@@ -16,6 +16,7 @@ export interface ConfirmDialogState {
     cancelLabel?: string;
     onOptional?: (isCancelled: boolean) => void;
     optionalLabel?: string;
+    hideCancel?: boolean;
 }
 
 const initialState: ConfirmDialogState = {};

--- a/src/ReduxConfirmDialog/reduxConfirmDialogSlice.ts
+++ b/src/ReduxConfirmDialog/reduxConfirmDialogSlice.ts
@@ -9,7 +9,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { RootState } from '../state';
 
 export interface ConfirmDialogState {
-    callback?: (isCancelled: boolean) => void;
+    callback: null | ((isCancelled: boolean) => void);
     title?: string;
     content?: string;
     confirmLabel?: string;
@@ -19,7 +19,9 @@ export interface ConfirmDialogState {
     hideCancel?: boolean;
 }
 
-const initialState: ConfirmDialogState = {};
+const initialState: ConfirmDialogState = {
+    callback: null,
+};
 
 const slice = createSlice({
     name: 'reduxConfirmDialog',

--- a/src/persistentStore.ts
+++ b/src/persistentStore.ts
@@ -4,12 +4,14 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
+import os from 'os';
 import path from 'path';
 import { getPersistentStore as store } from 'pc-nrfconnect-shared';
 
 import getNrfutilConfig from './Manager/nrfutil/config';
 
-const defaultInstallDir = getNrfutilConfig().install_dir;
+export const defaultInstallDir = getNrfutilConfig().install_dir;
+export const oldDefaultInstallDirOnWindows = path.resolve(os.homedir(), 'ncs');
 
 export const persistedInstallDir = (): string =>
     process.platform === 'darwin'
@@ -18,6 +20,8 @@ export const persistedInstallDir = (): string =>
 
 export const setPersistedInstallDir = (dir: string) =>
     store().set('installDir', dir);
+
+export const usesDefaultInstallDir = () => !store().has('installDir');
 
 const indexJson =
     {


### PR DESCRIPTION
When people used the TM on Windows before 1.0.0, their SDK environments were by default installed to `%USERPROFILE%\ncs`. If they never changed that default install directory and upgraded the TM to 1.0.0 they did not see their installed SDK environments any longer because now `C:/ncs` is used for their environments. 

(This did not happen on macOS or if the users ever changed their installation directory.)

The new behaviour: 

1. If users have SDK environments in `%USERPROFILE%\ncs` but **not** yet in `C:/ncs` then continue to use the old `%USERPROFILE%\ncs`.
2. If users have **no** SDK environments in `%USERPROFILE%\ncs` but already in `C:/ncs` then continue to use the new `C:/ncs`.
3. If users already have SDK environments in both,`%USERPROFILE%\ncs` and `C:/ncs`, then show them this dialog (of course with appropriate folders in it):
![Screenshot 2022-06-03 at 15 36 56](https://user-images.githubusercontent.com/260705/171869775-48413bbe-85d6-4b92-b94b-f1b66c83b70d.png)

