### PR TITLE
Fix/cancel install

### DIFF
--- a/src/Manager/Environment/Install.tsx
+++ b/src/Manager/Environment/Install.tsx
@@ -12,7 +12,7 @@ import { showConfirmInstallDirDialog } from '../../InstallDir/installDirSlice';
 import { Environment } from '../../state';
 import Button from './Button';
 import { install } from './effects/installEnvironment';
-import { isInProgress, isInstalled, version } from './environmentReducer';
+import { isInProgress, isOnlyAvailable, version } from './environmentReducer';
 
 type Props = { environment: Environment };
 
@@ -49,7 +49,7 @@ const Install = ({ environment }: Props) => {
         );
     }
 
-    if (!isInstalled(environment)) {
+    if (isOnlyAvailable(environment)) {
         return (
             <Button
                 icon="x-mdi-briefcase-download-outline"

--- a/src/Manager/Environment/Install.tsx
+++ b/src/Manager/Environment/Install.tsx
@@ -12,7 +12,12 @@ import { showConfirmInstallDirDialog } from '../../InstallDir/installDirSlice';
 import { Environment } from '../../state';
 import Button from './Button';
 import { install } from './effects/installEnvironment';
-import { isInProgress, isOnlyAvailable, version } from './environmentReducer';
+import {
+    isInProgress,
+    isLegacyEnvironment,
+    isOnlyAvailable,
+    version,
+} from './environmentReducer';
 
 type Props = { environment: Environment };
 
@@ -38,7 +43,10 @@ const Install = ({ environment }: Props) => {
         usageData.sendUsageData('Cancel installation', environment.version);
     };
 
-    if (isInProgress(environment)) {
+    if (
+        isInProgress(environment) &&
+        !isLegacyEnvironment(environment.version)
+    ) {
         return (
             <Button
                 icon="x-mdi-briefcase-download-outline"

--- a/src/Manager/Environment/Install.tsx
+++ b/src/Manager/Environment/Install.tsx
@@ -13,7 +13,7 @@ import { Environment } from '../../state';
 import Button from './Button';
 import { install } from './effects/installEnvironment';
 import {
-    isInProgress,
+    isDoingFreshInstall,
     isLegacyEnvironment,
     isOnlyAvailable,
     version,
@@ -44,7 +44,7 @@ const Install = ({ environment }: Props) => {
     };
 
     if (
-        isInProgress(environment) &&
+        isDoingFreshInstall(environment) &&
         !isLegacyEnvironment(environment.version)
     ) {
         return (

--- a/src/Manager/Environment/effects/cloneNcs.ts
+++ b/src/Manager/Environment/effects/cloneNcs.ts
@@ -55,9 +55,6 @@ export const cloneNcs =
                 await updateLegacy(justUpdate, toolchainDir, dispatch, version);
             } else {
                 await updateNrfUtil(version, dispatch, signal);
-                if (signal.aborted) {
-                    return;
-                }
             }
         } catch (error) {
             const errorMsg = `Failed to clone the repositories: ${error}`;

--- a/src/Manager/Environment/effects/cloneNcs.ts
+++ b/src/Manager/Environment/effects/cloneNcs.ts
@@ -62,6 +62,10 @@ export const cloneNcs =
             usageData.sendErrorReport(errorMsg);
         }
 
+        if (signal.aborted) {
+            return;
+        }
+
         dispatch(finishCloningSdk(version, isWestPresent(toolchainDir)));
 
         usageData.sendUsageData(

--- a/src/Manager/Environment/effects/installPackage.ts
+++ b/src/Manager/Environment/effects/installPackage.ts
@@ -63,6 +63,7 @@ export const installPackage =
                     toolchainDir,
                     isInstalled: false,
                     isWestPresent: false,
+                    abortController: new AbortController(),
                 })
             );
             dispatch(startInstallToolchain(version));

--- a/src/Manager/Environment/environmentReducer.ts
+++ b/src/Manager/Environment/environmentReducer.ts
@@ -151,6 +151,8 @@ export const isOnlyAvailable = (env: Environment) =>
     !isInstalled(env) && !isInProgress(env);
 export const canBeDownloaded = (env: Environment | undefined) =>
     env?.toolchains != null;
+export const isDoingFreshInstall = (env: Environment) =>
+    !env.isInstalled && (env.isCloningSdk || env.isInstallingToolchain);
 
 export const version = (env: Environment) => env.version;
 export const toolchainDir = (env: Environment) => env.toolchainDir;

--- a/src/Manager/initEnvironments.ts
+++ b/src/Manager/initEnvironments.ts
@@ -59,6 +59,7 @@ const detectLocallyExistingEnvironments = (dispatch: Dispatch) => {
                         toolchainDir,
                         isWestPresent: westPresent,
                         isInstalled: true,
+                        abortController: new AbortController(),
                     })
                 );
             });
@@ -134,7 +135,11 @@ const downloadIndex = (dispatch: Dispatch) => {
                 JSON.parse(result).forEach(
                     (environment: Omit<Environment, 'type'>) => {
                         dispatch(
-                            addEnvironment({ ...environment, type: 'legacy' })
+                            addEnvironment({
+                                ...environment,
+                                abortController: new AbortController(),
+                                type: 'legacy',
+                            })
                         );
                         logger.info(
                             `Toolchain ${environment.version} has been added to the list`

--- a/src/Manager/managerSlice.ts
+++ b/src/Manager/managerSlice.ts
@@ -116,6 +116,7 @@ const managerSlice = createSlice({
                 toolchainDir: string;
                 isWestPresent: boolean;
                 isInstalled: boolean;
+                abortController: AbortController;
             }>
         ) => {
             const environment: Environment = {

--- a/src/Manager/nrfutil/west.ts
+++ b/src/Manager/nrfutil/west.ts
@@ -62,7 +62,9 @@ const west = (
         });
         tcm.on('close', code => {
             signal.removeEventListener('abort', abortListener);
-            code === 0 || signal.aborted ? resolve() : reject();
+
+            if (code === 0 || signal.aborted) resolve();
+            else reject();
         });
     });
 

--- a/src/Manager/nrfutil/west.ts
+++ b/src/Manager/nrfutil/west.ts
@@ -30,6 +30,10 @@ const west = (
     onUpdate: (update: string) => void = noop
 ) =>
     new Promise<void>((resolve, reject) => {
+        if (signal.aborted) {
+            resolve();
+        }
+
         mkdirSync(sdkPath(version), {
             recursive: true,
         });


### PR DESCRIPTION
Fixes a few issues that were introduced with the cancel feature:

- TCM failed on any legacy toolchain action due to them not having an abortcontroller
- Legacy environments should not show cancel option
- Cancel option should only be available during a fresh install