### PR TITLE
Enhance fallback install dir

### DIFF
--- a/src/persistentStore.ts
+++ b/src/persistentStore.ts
@@ -18,7 +18,7 @@ import nrfutilToolchainManager from './Manager/nrfutil/nrfutilToolchainManager';
 const fallbackInstallDir = () =>
     ({
         win32: path.resolve('\\', 'ncs'),
-        darwin: '/opt/nordic/ncs',
+        darwin: path.resolve(path.sep, 'opt', 'nordic', 'ncs'),
         linux: path.resolve(os.homedir(), 'ncs'),
     }[<string>process.platform] ?? path.resolve(os.homedir(), 'ncs'));
 

--- a/src/persistentStore.ts
+++ b/src/persistentStore.ts
@@ -15,29 +15,32 @@ import {
 import getNrfutilConfig from './Manager/nrfutil/config';
 import nrfutilToolchainManager from './Manager/nrfutil/nrfutilToolchainManager';
 
-// Set fallback value in case nrfutil can't supply the value.
-let installDir =
-    {
+const fallbackInstallDir = () =>
+    ({
         win32: path.resolve('\\', 'ncs'),
         darwin: '/opt/nordic/ncs',
         linux: path.resolve(os.homedir(), 'ncs'),
-    }[<string>process.platform] ?? path.resolve(os.homedir(), 'ncs');
+    }[<string>process.platform] ?? path.resolve(os.homedir(), 'ncs'));
 
-try {
-    installDir = getNrfutilConfig().install_dir;
-} catch (error) {
-    // Use a timeout as usageData is not yet ready at this point.
-    setTimeout(() => {
-        usageData.sendErrorReport(
-            'Unable to get nrfutil-toolchain-manager config.'
-        );
-        logger.error(
-            `Please check if ${nrfutilToolchainManager()} is executable on your system.`
-        );
-    });
-}
+const installDir = () => {
+    try {
+        return getNrfutilConfig().install_dir;
+    } catch (error) {
+        // Use a timeout as usageData is not yet ready at this point.
+        setTimeout(() => {
+            usageData.sendErrorReport(
+                'Unable to get nrfutil-toolchain-manager config.'
+            );
+            logger.error(
+                `Please check if ${nrfutilToolchainManager()} is executable on your system.`
+            );
+        });
 
-export const defaultInstallDir = installDir;
+        return fallbackInstallDir();
+    }
+};
+
+export const defaultInstallDir = installDir();
 export const oldDefaultInstallDirOnWindows = path.resolve(os.homedir(), 'ncs');
 
 export const persistedInstallDir = (): string =>

--- a/src/persistentStore.ts
+++ b/src/persistentStore.ts
@@ -17,7 +17,7 @@ import nrfutilToolchainManager from './Manager/nrfutil/nrfutilToolchainManager';
 
 const fallbackInstallDir = () =>
     ({
-        win32: ['\\', 'ncs'],
+        win32: ['C:', 'ncs'],
         darwin: [path.sep, 'opt', 'nordic', 'ncs'],
         linux: [os.homedir(), 'ncs'],
     }[<string>process.platform] ?? [os.homedir(), 'ncs']);

--- a/src/persistentStore.ts
+++ b/src/persistentStore.ts
@@ -17,10 +17,10 @@ import nrfutilToolchainManager from './Manager/nrfutil/nrfutilToolchainManager';
 
 const fallbackInstallDir = () =>
     ({
-        win32: path.resolve('\\', 'ncs'),
-        darwin: path.resolve(path.sep, 'opt', 'nordic', 'ncs'),
-        linux: path.resolve(os.homedir(), 'ncs'),
-    }[<string>process.platform] ?? path.resolve(os.homedir(), 'ncs'));
+        win32: ['\\', 'ncs'],
+        darwin: [path.sep, 'opt', 'nordic', 'ncs'],
+        linux: [os.homedir(), 'ncs'],
+    }[<string>process.platform] ?? [os.homedir(), 'ncs']);
 
 const installDir = () => {
     try {
@@ -36,7 +36,7 @@ const installDir = () => {
             );
         });
 
-        return fallbackInstallDir();
+        return path.resolve(...fallbackInstallDir());
     }
 };
 


### PR DESCRIPTION
Fixes the issue that [on Windows another directory than `C:\ncs` might be used as default install dir](https://github.com/NordicSemiconductor/pc-nrfconnect-toolchain-manager/pull/165#pullrequestreview-1025988626).

Also restructures some things: 
* Move code from top level into functions.
* Consistently let the folders be created by `path.resolve`.
* Only have one mention of `path.resolve` instead of multiple.