### PR TITLE
Remove Cortex Debug from VS Code extension list

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 -   The `First Steps` button for SDK environments v2.0.0 and newer now link to
     an external resource.
 -   `Update toolchain` does not additionally update the SDK anymore.
+-   Cortex Debug was removed from the list of recommended VS Code extensions.
 
 ## 1.2.0
 

--- a/src/VsCodeDialog/vscode.ts
+++ b/src/VsCodeDialog/vscode.ts
@@ -29,7 +29,6 @@ const EXTENSIONS = [
         id: 'nordic-semiconductor.nrf-connect',
         name: 'nRF Connect',
     },
-    { id: 'marus25.cortex-debug', name: 'Cortex-Debug' },
     {
         id: 'nordic-semiconductor.nrf-terminal',
         name: 'nRF Terminal',


### PR DESCRIPTION
We will be launching our own debugger in the next extension release, so it's no longer appropriate to recommend Cortex Debug.

## Checklist

- [X] Ensure all user facing text is spell checked.
- [ ] Bump version in package.json
- [X] Update changelog
- [X] Write tests if needed
