### PR TITLE
Correct engine specification

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "author": "Nordic Semiconductor ASA",
     "license": "SEE LICENSE IN LICENSE",
     "engines": {
-        "nrfconnect": "^3.11.1"
+        "nrfconnect": ">=3.11.1"
     },
     "main": "dist/bundle.js",
     "files": [


### PR DESCRIPTION
The caret was wrong because we expect the app to continue to work with also future major versions like `4.0.0`.