### PR TITLE
fix: Path environment variable was incomplete and wrong on windows

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.2.2 - Unreleased
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-toolchain-manager",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Install and manage tools to develop with the nRF Connect SDK (NCS)",
     "displayName": "Toolchain Manager",
     "homepage": "https://github.com/NordicPlayground/pc-nrfconnect-toolchain-manager",

--- a/src/Manager/nrfutil/nrfutilChildProcess.ts
+++ b/src/Manager/nrfutil/nrfutilChildProcess.ts
@@ -39,8 +39,15 @@ const updateEnv = (
         delete env[key];
     });
 
-    if (process.platform === 'win32')
-        env.PATH = `${vcRuntimeDllPath()}${path.delimiter}${env.PATH}`;
+    if (process.platform === 'win32') {
+        // For some reason only `env.Path` exists after spreading process.env above,
+        // despite process.env including `path`, `Path` and `PATH`.
+        // After spawning a process however, windows only recognizes `PATH` in the env
+        // We extract process.env.PATH here to make it explicit
+        const PATH = process.env.PATH;
+
+        env.PATH = `${vcRuntimeDllPath()}${path.delimiter}${PATH}`;
+    }
 
     return env;
 };


### PR DESCRIPTION
After spreading process.env only `Path` was a valid property. Since we used `PATH` as a getter we ended up with `undefined` in the final path environment variable.

