### PR TITLE
Fix/handle failed remove

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 ### Fixed
 
 -   For some older toolchains no download progress was printed.
+-   Removing toolchains never appeared to stop when it produced and error.
 
 ## 1.2.1 - 2022-19-10
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 ### Fixed
 
 -   For some older toolchains no download progress was printed.
--   Removing toolchains never appeared to stop when it produced and error.
+-   Removing toolchains never appeared to stop when it produced an error.
 
 ## 1.2.1 - 2022-19-10
 

--- a/src/Manager/Environment/RemoveEnvironmentDialog.tsx
+++ b/src/Manager/Environment/RemoveEnvironmentDialog.tsx
@@ -31,8 +31,8 @@ export default () => {
                 dispatch(removeEnvironment(environment));
             }}
         >
-            Are you sure to remove <code>{version(environment)}</code>{' '}
-            environment?
+            Are you sure to you want to remove{' '}
+            <code>{version(environment)}</code> environment?
         </ConfirmationDialog>
     );
 };

--- a/src/Manager/Environment/RemoveEnvironmentDialog.tsx
+++ b/src/Manager/Environment/RemoveEnvironmentDialog.tsx
@@ -31,8 +31,8 @@ export default () => {
                 dispatch(removeEnvironment(environment));
             }}
         >
-            Are you sure to you want to remove{' '}
-            <code>{version(environment)}</code> environment?
+            Are you sure you want to remove <code>{version(environment)}</code>{' '}
+            environment?
         </ConfirmationDialog>
     );
 };

--- a/src/Manager/Environment/effects/ensureCleanTargetDir.ts
+++ b/src/Manager/Environment/effects/ensureCleanTargetDir.ts
@@ -34,7 +34,7 @@ export const ensureCleanTargetDir =
             if (toBeDeleted) {
                 try {
                     await dispatch(confirmRemoveDir(toBeDeleted));
-                    removeDir(toBeDeleted);
+                    await removeDir(toBeDeleted);
                 } catch (err) {
                     throw new Error(
                         `${toBeDeleted} must be removed to continue installation`

--- a/src/Manager/Environment/effects/ensureCleanTargetDir.ts
+++ b/src/Manager/Environment/effects/ensureCleanTargetDir.ts
@@ -34,7 +34,7 @@ export const ensureCleanTargetDir =
             if (toBeDeleted) {
                 try {
                     await dispatch(confirmRemoveDir(toBeDeleted));
-                    await removeDir(dispatch, toBeDeleted);
+                    removeDir(toBeDeleted);
                 } catch (err) {
                     throw new Error(
                         `${toBeDeleted} must be removed to continue installation`

--- a/src/Manager/Environment/effects/installEnvironment.ts
+++ b/src/Manager/Environment/effects/installEnvironment.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import path from 'path';
 import {
     describeError,
     ErrorDialogActions,
@@ -13,7 +12,6 @@ import {
 } from 'pc-nrfconnect-shared';
 
 import {
-    persistedInstallDir as installDir,
     persistedShowVsCodeDialogDuringInstall,
     setPersistedShowVsCodeDialogDuringInstall,
 } from '../../../persistentStore';
@@ -26,7 +24,7 @@ import {
     VsCodeStatus,
 } from '../../../VsCodeDialog/vscodeSlice';
 import { getLatestToolchain } from '../../managerSlice';
-import { isLegacyEnvironment } from '../environmentReducer';
+import toolchainPath from '../../toolchainPath';
 import checkXcodeCommandLineTools from './checkXcodeCommandLineTools';
 import { cloneNcs } from './cloneNcs';
 import { ensureCleanTargetDir } from './ensureCleanTargetDir';
@@ -41,9 +39,7 @@ export const install =
     async (dispatch: Dispatch) => {
         logger.info(`Start to install toolchain ${version}`);
         const toolchain = getLatestToolchain(toolchains);
-        const toolchainDir = isLegacyEnvironment(version)
-            ? path.resolve(installDir(), version, 'toolchain')
-            : path.resolve(installDir(), 'toolchains', version);
+        const toolchainDir = toolchainPath(version);
         logger.info(`Installing ${toolchain?.name} at ${toolchainDir}`);
         logger.debug(`Install with toolchain version ${toolchain?.version}`);
         logger.debug(`Install with sha512 ${toolchain?.sha512}`);

--- a/src/Manager/Environment/effects/removeDir.ts
+++ b/src/Manager/Environment/effects/removeDir.ts
@@ -6,16 +6,11 @@
 
 import fse from 'fs-extra';
 import path from 'path';
-import { ErrorDialogActions, usageData } from 'pc-nrfconnect-shared';
 
-import { Dispatch } from '../../../state';
-
-export const removeDir = async (dispatch: Dispatch, srcDir: string) => {
-    let renameOfDirSuccessful = false;
+export const removeDir = async (srcDir: string) => {
+    const toBeDeletedDir = path.resolve(srcDir, '..', 'toBeDeleted');
     try {
-        const toBeDeletedDir = path.resolve(srcDir, '..', 'toBeDeleted');
-        await fse.move(srcDir, toBeDeletedDir, { overwrite: true });
-        renameOfDirSuccessful = true;
+        await fse.rename(srcDir, toBeDeletedDir);
         await fse.remove(toBeDeletedDir);
     } catch (error) {
         const [, , message] = `${error}`.split(/[:,] /);
@@ -23,8 +18,7 @@ export const removeDir = async (dispatch: Dispatch, srcDir: string) => {
             `Failed to remove ${srcDir}, ${message}. ` +
             'Please close any application or window that might keep this ' +
             'environment locked, then try to remove it again.';
-        dispatch(ErrorDialogActions.showDialog(errorMsg));
-        usageData.sendErrorReport(errorMsg);
+
+        throw new Error(errorMsg);
     }
-    return renameOfDirSuccessful;
 };

--- a/src/Manager/Environment/effects/removeDir.ts
+++ b/src/Manager/Environment/effects/removeDir.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import fs from 'fs';
+import { rename, rm } from 'fs/promises';
 import path from 'path';
 
-export const removeDir = (srcDir: string) => {
+export const removeDir = async (srcDir: string) => {
     const toBeDeletedDir = path.resolve(srcDir, '..', 'toBeDeleted');
     try {
-        fs.renameSync(srcDir, toBeDeletedDir);
-        fs.rmSync(toBeDeletedDir, { recursive: true, force: true });
+        await rename(srcDir, toBeDeletedDir);
+        await rm(toBeDeletedDir);
     } catch (error) {
         const [, , message] = `${error}`.split(/[:,] /);
         const errorMsg =

--- a/src/Manager/Environment/effects/removeDir.ts
+++ b/src/Manager/Environment/effects/removeDir.ts
@@ -7,11 +7,11 @@
 import fse from 'fs-extra';
 import path from 'path';
 
-export const removeDir = async (srcDir: string) => {
+export const removeDir = (srcDir: string) => {
     const toBeDeletedDir = path.resolve(srcDir, '..', 'toBeDeleted');
     try {
-        await fse.rename(srcDir, toBeDeletedDir);
-        await fse.remove(toBeDeletedDir);
+        fse.renameSync(srcDir, toBeDeletedDir);
+        fse.removeSync(toBeDeletedDir);
     } catch (error) {
         const [, , message] = `${error}`.split(/[:,] /);
         const errorMsg =

--- a/src/Manager/Environment/effects/removeDir.ts
+++ b/src/Manager/Environment/effects/removeDir.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import fse from 'fs-extra';
+import fs from 'fs';
 import path from 'path';
 
 export const removeDir = (srcDir: string) => {
     const toBeDeletedDir = path.resolve(srcDir, '..', 'toBeDeleted');
     try {
-        fse.renameSync(srcDir, toBeDeletedDir);
-        fse.removeSync(toBeDeletedDir);
+        fs.renameSync(srcDir, toBeDeletedDir);
+        fs.rmSync(toBeDeletedDir, { recursive: true, force: true });
     } catch (error) {
         const [, , message] = `${error}`.split(/[:,] /);
         const errorMsg =

--- a/src/Manager/Environment/effects/removeEnvironment.ts
+++ b/src/Manager/Environment/effects/removeEnvironment.ts
@@ -33,7 +33,7 @@ const removeNrfutilEnvironment = (version: string) => {
     } catch (err) {
         throw new Error(
             `Failed to remove ${sdkPath(version)}, ${err}. ` +
-                `The installation for ${version} is likely broken and has to be removed manually by the user.`
+                `Please remove the installation for ${version} manually as it is broken.`
         );
     }
 };

--- a/src/Manager/Environment/effects/removeEnvironment.ts
+++ b/src/Manager/Environment/effects/removeEnvironment.ts
@@ -26,11 +26,13 @@ import { removeDir } from './removeDir';
 const removeLegacyEnvironment = (toolchainDir: string) =>
     removeDir(path.dirname(toolchainDir));
 
-const removeNrfutilEnvironment = (version: string) =>
-    Promise.all([removeDir(sdkPath(version)), removeToolchain(version)]);
+const removeNrfutilEnvironment = (version: string) => {
+    removeDir(sdkPath(version));
+    removeToolchain(version);
+};
 
 export const removeEnvironment =
-    (environment: Environment) => async (dispatch: Dispatch) => {
+    (environment: Environment) => (dispatch: Dispatch) => {
         const { toolchainDir, version } = environment;
         logger.info(`Removing ${version} at ${toolchainDir}`);
         usageData.sendUsageData(EventAction.REMOVE_TOOLCHAIN, `${version}`);
@@ -39,9 +41,9 @@ export const removeEnvironment =
 
         try {
             if (isLegacyEnvironment(version)) {
-                await removeLegacyEnvironment(toolchainDir);
+                removeLegacyEnvironment(toolchainDir);
             } else {
-                await removeNrfutilEnvironment(version);
+                removeNrfutilEnvironment(version);
             }
         } catch (err) {
             dispatch(

--- a/src/Manager/Environment/effects/removeEnvironment.ts
+++ b/src/Manager/Environment/effects/removeEnvironment.ts
@@ -28,7 +28,14 @@ const removeLegacyEnvironment = (toolchainDir: string) =>
 
 const removeNrfutilEnvironment = (version: string) => {
     removeDir(sdkPath(version));
-    removeToolchain(version);
+    try {
+        removeToolchain(version);
+    } catch (err) {
+        throw new Error(
+            `Failed to remove ${sdkPath(version)}, ${err}. ` +
+                `The installation for ${version} is likely broken and has to be removed manually by the user.`
+        );
+    }
 };
 
 export const removeEnvironment =

--- a/src/Manager/toolchainPath.ts
+++ b/src/Manager/toolchainPath.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import path from 'path';
+
+import { persistedInstallDir } from '../persistentStore';
+import { isLegacyEnvironment } from './Environment/environmentReducer';
+
+// The nrfutil environments should use nrfutil to get the toolchain path as soon as that feature exists.
+export default (version: string, ...params: string[]) =>
+    isLegacyEnvironment(version)
+        ? path.resolve(persistedInstallDir(), version, 'toolchain', ...params)
+        : path.resolve(persistedInstallDir(), 'toolchains', version, ...params);


### PR DESCRIPTION
Toolchain manager didn't handle an error during the removal of a toolchain/sdk properly.

Currently it will detect if the SDK can be deleted by attempting to rename the sdk folder. If this fails it will prompt the user to close whatever application is keeping the folder locked and to try again.

If however the toolchain folder fails to be deleted, a prompt will tell the user that the installation is broken and has to be removed manually. 