### PR TITLE
doc: replace Infocenter links

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 -   Moved feedback tab to a dialog which can be opened by going to the about tab
     and click **Give Feedback**.
+-   Updated documentation links to point to the TechDocs platform.
 
 ## 1.3.1 - 2024-03-13
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 ## Installation
 
-nRF Connect Toolchain Manager is installed from nRF Connect from Desktop. For detailed
-steps, see
+nRF Connect Toolchain Manager is installed from nRF Connect from Desktop. For
+detailed steps, see
 [Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html)
 in the nRF Connect from Desktop documentation.
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 
 ## Installation
 
-See the
-[InfoCenter](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fstruct_nrftools%2Fstruct%2Fnrftools_nrfconnect.html)
-pages for information on how to install the application.
+nRF Connect Toolchain Manager is installed from nRF Connect from Desktop. For detailed
+steps, see
+[Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html)
+in the nRF Connect from Desktop documentation.
 
 ## Development
 
@@ -22,7 +23,7 @@ Please report issues on the [DevZone](https://devzone.nordicsemi.com) portal.
 ## Contributing
 
 See the
-[infos on contributing](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/contributing)
+[information on contributing](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/contributing)
 for details.
 
 ## License

--- a/src/FirstInstall/FirstInstallInstructions.tsx
+++ b/src/FirstInstall/FirstInstallInstructions.tsx
@@ -279,7 +279,7 @@ const SEGGER = ({ version }: { version: string }) => (
                         <a
                             target="_blank"
                             rel="noopener noreferrer"
-                            href="https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/nrf9160/spm/README.html#secure-partition-manager"
+                            href="https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/security/tfm.html"
                         >
                             SPM
                         </a>
@@ -299,7 +299,7 @@ const SEGGER = ({ version }: { version: string }) => (
                             <a
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                href="https://infocenter.nordicsemi.com/topic/ug_nrf91_dk/UG/nrf91_DK/mcu_device_programming.html"
+                                href="https://docs.nordicsemi.com/bundle/ug_nrf91_dk/page/UG/nrf91_DK/mcu_device_programming.html"
                             >
                                 Device programming section in the nRF9160 DK
                                 User Guide

--- a/src/Manager/Environment/ShowFirstSteps.tsx
+++ b/src/Manager/Environment/ShowFirstSteps.tsx
@@ -38,7 +38,7 @@ const ShowFirstSteps = ({ environment }: Props) => {
             label="First steps"
             title="Show how to build a sample project (External website)"
             variant="secondary"
-            href="https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/create_application.html"
+            href="https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/create_application.html"
             target="_blank"
         />
     );

--- a/src/Manager/PlatformInstructions.tsx
+++ b/src/Manager/PlatformInstructions.tsx
@@ -13,7 +13,7 @@ const OnlineDocs: FC<{ label: string }> = ({ label }) => (
     <a
         target="_blank"
         rel="noopener noreferrer"
-        href="https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/gs_installing.html"
+        href="https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/installation/install_ncs.html"
     >
         {label}
     </a>


### PR DESCRIPTION
Replaced Infocenter links with TechDocs ones.
