### PR TITLE
Use .eslintrc.js instead of eslintConfig

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+module.exports = require('@nordicsemiconductor/pc-nrfconnect-shared/config/eslintrc');

--- a/package.json
+++ b/package.json
@@ -54,9 +54,6 @@
         "extract-zip": "^2.0.1",
         "fs-extra": "^8.1.0"
     },
-    "eslintConfig": {
-        "extends": "./node_modules/@nordicsemiconductor/pc-nrfconnect-shared/config/eslintrc.js"
-    },
     "prettier": "@nordicsemiconductor/pc-nrfconnect-shared/config/prettier.config.js",
     "bundleDependencies": [
         "extract-zip",


### PR DESCRIPTION
Using a .eslintrc.js file is more flexible and the preferred way in all our projects. It has the advantage, that it makes it easier to adapt the ESLint configuration, e.g. to exclude files from linting as it is done in pc-nrfconnect-npm.
