### PR TITLE
Update documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 nRF Connect Toolchain Manager is installed from nRF Connect from Desktop. For
 detailed steps, see
-[Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html)
+[Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/swtools_docs/page/app/nrf-connect-desktop/installing_apps.html)
 in the nRF Connect from Desktop documentation.
 
 ## Development


### PR DESCRIPTION
https://docs.nordicsemi.com/bundle/nrf-connect-desktop is the outdated bundle which is not updated anymore. Correct is now to link to https://docs.nordicsemi.com/bundle/swtools_docs.
